### PR TITLE
Added regular expression support to besside-ng

### DIFF
--- a/INSTALLING
+++ b/INSTALLING
@@ -54,7 +54,7 @@ to compile and install the suite:
 		LibNL 1: libnl-dev 
 		LibNL 3: libnl-3-dev and libnl-genl-3-dev.
 
-* pcre:	    Add support for regular expression matching for ESSID in airodump-ng.
+* pcre:	    Add support for regular expression matching for ESSID in airodump-ng and besside-ng.
             Dependencies (debian): libpcre3-dev
 
 Example:

--- a/src/Makefile
+++ b/src/Makefile
@@ -3,7 +3,7 @@ include $(AC_ROOT)/common.mak
 
 TEST_DIR	= $(AC_ROOT)/test
 
-CFLAGS		+= -Iinclude -g
+CFLAGS		+= -Iinclude
 
 iCC             = $(shell find /opt/intel/cc/*/bin/icc)
 iCFLAGS         = -w -mcpu=pentiumpro -march=pentiumpro $(COMMON_CFLAGS)

--- a/src/Makefile
+++ b/src/Makefile
@@ -3,7 +3,7 @@ include $(AC_ROOT)/common.mak
 
 TEST_DIR	= $(AC_ROOT)/test
 
-CFLAGS		+= -Iinclude
+CFLAGS		+= -Iinclude -g
 
 iCC             = $(shell find /opt/intel/cc/*/bin/icc)
 iCFLAGS         = -w -mcpu=pentiumpro -march=pentiumpro $(COMMON_CFLAGS)
@@ -165,7 +165,7 @@ buddy-ng$(EXE): $(OBJS_BUDDY)
 	$(CC) $(CFLAGS) $(LDFLAGS) $(OBJS_BUDDY) -o $(@) $(LDFLAGS)
 
 besside-ng$(EXE): $(OBJS_BS) $(LIBOSD)
-	$(CC) $(CFLAGS) $(LDFLAGS) $(OBJS_BS) -o $(@) $(LIBS) $(LIBSSL) -lz
+	$(CC) $(CFLAGS) $(LDFLAGS) $(OBJS_BS) -o $(@) $(LIBS) $(LIBSSL) -lz $(LIBPCRE)
 
 besside-ng-crawler$(EXE): $(OBJS_BC)
 	$(CC) $(CFLAGS) $(LDFLAGS) $(OBJS_BC) -o $(@) -lpcap

--- a/src/besside-ng.c
+++ b/src/besside-ng.c
@@ -52,6 +52,10 @@
 #include <netdb.h>
 #include <unistd.h>
 
+#ifdef HAVE_PCRE
+#include <pcre.h>
+#endif
+
 #include "aircrack-ng.h"
 #include "version.h"
 #include "aircrack-ptw-lib.h"
@@ -148,6 +152,9 @@ struct conf {
 	int		cf_do_wep;
 	int		cf_do_wpa;
 	char		*cf_wpa_server;
+#ifdef HAVE_PCRE
+    pcre *cf_essid_regex;
+#endif
 } _conf;
 
 struct timer {
@@ -1127,6 +1134,20 @@ static void attack_ping(void *a)
 	timer_in(100 * 1000, attack_ping, n);
 }
 
+#ifdef HAVE_PCRE
+int is_filtered_essid(char *essid)
+{
+    int ret = 0;
+
+    if(_conf.cf_essid_regex)
+    {
+        return pcre_exec(_conf.cf_essid_regex, NULL, (char*)essid, IEEE80211_MAX_SSID_LEN, 0, 0, NULL, 0) < 0;
+    }
+
+    return ret;
+}
+#endif
+
 // this should always return true -sorbo
 static int should_attack(struct network *n)
 {
@@ -1134,7 +1155,13 @@ static int should_attack(struct network *n)
 	    && memcmp(_conf.cf_bssid , n->n_bssid, 6) != 0)
 		return 0;
 
-	if (!n->n_have_beacon)
+#ifdef HAVE_PCRE
+    if (is_filtered_essid(n->n_ssid)) {
+        return 0;
+    }
+#endif
+
+    if (!n->n_have_beacon)
 		return 0;
 
 	switch (n->n_astate) {
@@ -2516,7 +2543,7 @@ static void wifi_read(void)
 	unsigned char buf[2048];
 	int rd;
 	struct rx_info ri;
-        struct ieee80211_frame* wh = (struct ieee80211_frame*) buf;
+    struct ieee80211_frame* wh = (struct ieee80211_frame*) buf;
 	struct network *n;
 
 	rd = wi_read(s->s_wi, buf, sizeof(buf), &ri);
@@ -3112,6 +3139,9 @@ static void usage(char *prog)
                 "  Options:\n"
                 "\n"
                 "       -b <victim mac> : Victim BSSID\n"
+#ifdef HAVE_PCRE
+                "       -R <victim ap regex> : Victim ESSID regex\n"
+#endif
 		"       -s <WPA server> : Upload wpa.cap for cracking\n"
 		"       -c       <chan> : chanlock\n"
 		"       -p       <pps>  : flood rate\n"
@@ -3128,10 +3158,14 @@ static void usage(char *prog)
 int main(int argc, char *argv[])
 {
 	int ch;
+#ifdef HAVE_PCRE
+    const char *pcreerror;
+    int pcreerroffset;
+#endif
 
 	init_conf();
 
-	while ((ch = getopt(argc, argv, "hb:vWs:c:p:")) != -1) {
+	while ((ch = getopt(argc, argv, "hb:vWs:c:p:R:")) != -1) {
 		switch (ch) {
 		case 's':
 			_conf.cf_wpa_server = optarg;
@@ -3162,6 +3196,22 @@ int main(int argc, char *argv[])
 			parse_hex(_conf.cf_bssid, optarg, 6);
 			break;
 
+#ifdef HAVE_PCRE
+        case 'R':
+            if (_conf.cf_essid_regex != NULL) {
+                printf("Error: ESSID regular expression already given. Aborting\n");
+                exit(1);
+            }
+
+            _conf.cf_essid_regex = pcre_compile(optarg, 0, &pcreerror, &pcreerroffset, NULL);
+
+            if (_conf.cf_essid_regex == NULL) {
+                printf("Error: regular expression compilation failed at offset %d: %s; aborting\n", pcreerroffset, pcreerror);
+                exit(1);
+            }
+            break;
+#endif
+
 		default:
 		case 'h':
 			usage(argv[0]);
@@ -3183,6 +3233,11 @@ int main(int argc, char *argv[])
 	signal(SIGCHLD, do_wait);
 
 	pwn();
+
+#ifdef HAVE_PCRE
+    if(_conf.cf_essid_regex)
+        pcre_free(_conf.cf_essid_regex);
+#endif
 
 	exit(0);
 }

--- a/src/include/ieee80211.h
+++ b/src/include/ieee80211.h
@@ -609,6 +609,12 @@ enum {
 	(sizeof(struct ieee80211_frame_min) + IEEE80211_CRC_LEN)
 
 /*
+ * Maximum ESSID name as defined by latest kernel headers
+ */
+
+#define IEEE80211_MAX_SSID_LEN     32
+
+/*
  * The 802.11 spec says at most 2007 stations may be
  * associated at once.  For most AP's this is way more
  * than is feasible so we use a default of 128.  This


### PR DESCRIPTION
Quite similar to airodump-ng but for besside-ng:

```
$ sudo ./besside-ng -R "NETGEAR*" mon0
[23:45:54] Let's ride
[23:45:54] Resuming from besside.log
[23:45:54] Appending to wpa.cap
[23:45:54] Appending to wep.cap
[23:45:54] Logging to besside.log
[23:46:02] TO-OWN [NETGEAR24*] OWNED []
(...)
```
