### PR TITLE
gps_tracker stack overflow

### DIFF
--- a/src/aireplay-ng.c
+++ b/src/aireplay-ng.c
@@ -5398,6 +5398,8 @@ int tcp_test(const char* ip_str, const short port)
         if( (unsigned)caplen == sizeof(nh))
         {
             len = ntohl(nh.nh_len);
+            if (len > 1024 || len < 0)
+                continue;
             if( nh.nh_type == 1 && i==0 )
             {
                 i=1;

--- a/src/airodump-ng.c
+++ b/src/airodump-ng.c
@@ -4497,7 +4497,7 @@ void gps_tracker( void )
         	}
 
         	// New version, JSON
-        	if( recv( gpsd_sock, line + pos, sizeof( line ) - 1, 0 ) <= 0 )
+        	if( recv( gpsd_sock, line + pos, sizeof( line ) - pos - 1, 0 ) <= 0 )
         		return;
 
         	// search for TPV class: {"class":"TPV"


### PR DESCRIPTION
I found a stack overflow at gps_tracker() in airodump-ng. The function receives a string(line) from server and checks if the string "{\"class\":\"DEVICES\",\"devices\":[]}" exists, otherwise it will store the length of the string to a int variable "pos". Afterwards the function receives a string stored to the same buffer plus the "pos" variable. A stack overflow occurs because the last recv() could write 256 bytes to an arbitary position 

char line[256];
int pos;
recv( gpsd_sock, line, sizeof( line ) - 1, 0 );
...
pos = strlen(line);
recv( gpsd_sock, line+pos, sizeof( line ) - 1, 0 );
