### PR TITLE
aireplay-ng tcp_test stack overflow

### DIFF
--- a/src/aireplay-ng.c
+++ b/src/aireplay-ng.c
@@ -5398,6 +5398,8 @@ int tcp_test(const char* ip_str, const short port)
         if( (unsigned)caplen == sizeof(nh))
         {
             len = ntohl(nh.nh_len);
+            if (len > 1024 || len < 0)
+                continue;
             if( nh.nh_type == 1 && i==0 )
             {
                 i=1;


### PR DESCRIPTION
I found a stack overflow at tcp_test function in aireplay-ng. The function tcp_test reads from server a struct which contains the length of the next recv() without proper checking of buffer bounds which leads to buffer overflow
