### PR TITLE
buddy-ng memcpy length parameter inconsistency

### DIFF
--- a/src/buddy-ng.c
+++ b/src/buddy-ng.c
@@ -83,6 +83,8 @@ int handle(int s, unsigned char* data, int len, struct sockaddr_in *s_in)
 	*cmd++ = htons(S_CMD_PACKET);
 	*cmd++ = *pid;
 	plen = len - 2;
+    if (plen < 0)
+        return 0;
 
 	last_id = ntohs(*pid);
 	if (last_id > 20000)


### PR DESCRIPTION
handle function subtracts two from len argument and then copies data to cmd with length "len". A segmentation fault occurs when len is equals to one and the result of subtraction is -1
