### PR TITLE
net_get assigns negative integer to len argument

### DIFF
--- a/src/osdep/network.c
+++ b/src/osdep/network.c
@@ -131,7 +131,7 @@ int net_get(int s, void *arg, int *len)
 	if (!(plen <= *len))
 		printf("PLEN %d type %d len %d\n",
 			plen, nh.nh_type, *len);
-	assert(plen <= *len); /* XXX */
+	assert(plen <= *len && plen > 0); /* XXX */
 
 	*len = plen;
 	if ((*len) && (net_read_exact(s, arg, *len) == -1))


### PR DESCRIPTION
net_get reads nh structure which contains a length field. The length field is assigned to len argument and gets returned by reference. A segmentation fault can occur if a malicious server sends back a negative length. As a result net_get will return with a negative length which may be used erroneously as valid. As an example the function net_get_nopacket:
net_get( pn->pn_s, buf, &l);
memcpy(arg, buf, l);
