### PR TITLE
airodump-ng: Support to show a WPS column with WPS version, config method(s) and AP setup locked, for APs with WPS enabled.

### DIFF
--- a/manpages/airodump-ng.8
+++ b/manpages/airodump-ng.8
@@ -107,6 +107,9 @@ Invert sorting algorithm
 .I m
 Mark the selected AP or cycle through different colors if the selected AP is already marked
 .TP
+.I o
+Display manufacturer prefix on BSSID and STATION
+.TP
 .I r
 (De-)Activate realtime sorting - applies sorting algorithm everytime the display will be redrawn
 .TP
@@ -206,6 +209,9 @@ The so-called "SSID", which can be empty if SSID hiding is activated. In this ca
 .TP
 .I MANUFACTURER
 This is only displayed when --manufacturer (or -M) is specified.
+.TP
+.I -n, --ethers
+Map MAC addresses of APs and clients to names using the given ethers file. See ethers(5) for the file format. Note that only the first 17 characters of the name are shown (which is the size of a MAC address in the normal human readable form).
 .TP
 .I STATION
 MAC address of each associated station or stations searching for an AP to connect with. Clients not currently associated with an AP have a BSSID of "(not associated)".

--- a/manpages/airodump-ng.8
+++ b/manpages/airodump-ng.8
@@ -59,6 +59,9 @@ Display a manufacturer column with the information obtained from the IEEE OUI li
 .I -U, --uptime
 Display APs uptime obtained from its beacon timestamp.
 .TP
+.I -W, --wps
+Display a WPS column with WPS version, config method(s), AP Setup Locked obtained from APs beacon or probe response (if any).
+.TP
 .I --output-format <formats>
 Define the formats to use (separated by a comma). Possible values are: pcap, ivs, csv, gps, kismet, netxml. The default values are: pcap, csv, kismet, kismet-newcore.
 \(aqpcap\(aq is for recording a capture in pcap format, \(aqivs\(aq is for ivs format (it is a shortcut for --ivs). \(aqcsv\(aq will create an airodump-ng CSV file, \(aqkismet\(aq will create a kismet csv file and \(aqkismet-newcore\(aq will create the kismet netxml file. \(aqgps\(aq is a shortcut for --gps.
@@ -192,8 +195,17 @@ The cipher detected. One of CCMP, WRAP, TKIP, WEP, WEP40, or WEP104. Not mandato
 .I AUTH
 The authentication protocol used. One of MGT (WPA/WPA2 using a separate authentication server), SKA (shared key for WEP), PSK (pre-shared key for WPA/WPA2), or OPN (open for WEP).
 .TP
+.I UPTIME
+This is only displayed when --uptime (or -U) is specified.
+.TP
+.I WPS
+This is only displayed when --wps (or -W) is specified. If the AP supports WPS, the first field of the column indicates version supported. The second field indicates WPS config methods (can be more than one method, separated by comma): USB = USB method, ETHER = Ethernet, LAB = Label, DISP = Display, EXTNFC = External NFC, INTNFC = Internal NFC, NFCINTF = NFC Interface, PBC = Push Button, KPAD =  Keypad. Locked is displayed when AP setup is locked.
+.TP
 .I ESSID
 The so-called "SSID", which can be empty if SSID hiding is activated. In this case, airodump-ng will try to recover the SSID from probe responses and association requests.
+.TP
+.I MANUFACTURER
+This is only displayed when --manufacturer (or -M) is specified.
 .TP
 .I STATION
 MAC address of each associated station or stations searching for an AP to connect with. Clients not currently associated with an AP have a BSSID of "(not associated)".

--- a/scripts/airodump-ng-oui-update
+++ b/scripts/airodump-ng-oui-update
@@ -7,17 +7,28 @@ OUI_DOWNLOAD_URL="http://standards.ieee.org/develop/regauth/oui/oui.txt"
 OUI_PATH0="/etc/aircrack-ng"
 OUI_PATH1="/usr/local/etc/aircrack-ng"
 OUI_PATH2="/usr/share/aircrack-ng"
-if [ -d "$OUI_PATH0" ]; then
-	OUI_PATH="$OUI_PATH0"
-elif [ -d "$OUI_PATH1" ]; then
-	OUI_PATH="$OUI_PATH1"
-elif [ -d "$OUI_PATH2" ]; then
-	OUI_PATH="$OUI_PATH2"
-else
-	# default
-	OUI_PATH="$OUI_PATH0"
-fi
+for OUI in \
+    "/etc/aircrack-ng/airodump-ng-oui.txt" \
+    "/usr/local/etc/aircrack-ng/airodump-ng-oui.txt" \
+    "/usr/share/aircrack-ng/airodump-ng-oui.txt" \
+    "/var/lib/misc/oui.txt" \
+    "/usr/share/misc/oui.txt" \
+    "/var/lib/ieee-data/oui.txt" \
+    "/usr/share/ieee-data/oui.txt" \
+    "/etc/manuf/oui.txt" \
+    "/usr/share/wireshark/wireshark/manuf/oui.txt" \
+    "/usr/share/wireshark/manuf/oui.txt" \
+    "NULL"
+do
+	if [ -d "$(dirname "$OUI")" ]; then
+		break
+	fi
+done
 
+if [ "$OUI" = "NULL" ]; then
+	OUI="${OUI_PATH0}/airodump-ng-oui.txt"
+fi
+OUI_PATH="$(dirname "$OUI")"
 AIRODUMP_NG_OUI="${OUI_PATH}/airodump-ng-oui.txt"
 OUI_IEEE="${OUI_PATH}/oui.txt"
 USERID=""
@@ -40,9 +51,7 @@ then
 fi
 
 
-if [ ! -d "${OUI_PATH}" ]; then
-	mkdir -p ${OUI_PATH}
-fi
+mkdir -p ${OUI_PATH}
 
 if [ ${CURL} ] || [ ${WGET} ]; then
 	# Delete previous partially downloaded file (if the script was aborted)
@@ -66,19 +75,30 @@ if [ ${CURL} ] || [ ${WGET} ]; then
 	echo "[*] Parsing OUI file..."
 
 	# Keep the previous file
-	if [ -f "${OUI_DOWNLOADED}" ]; then
-		mv ${AIRODUMP_NG_OUI} ${OUI}-old
+	if [ -f "${AIRODUMP_NG_OUI}" ]; then
+		mv ${AIRODUMP_NG_OUI} ${AIRODUMP_NG_OUI}-old
 	fi
 
 	# Parse it
 	grep "(hex)" ${OUI_IEEE} | sed 's/^[ \t]*//g;s/[ \t]*$//g' > ${AIRODUMP_NG_OUI}
-	if [ "${?}" -ne 0 ]; then
+	if [ ! -s "${AIRODUMP_NG_OUI}" ]; then
+		if [ -f "${AIRODUMP_NG_OUI}-old" ]; then
+			mv ${AIRODUMP_NG_OUI}-old ${AIRODUMP_NG_OUI}
+		fi
 		echo "[*] Error: Failed to parse OUI, aborting..."
 		exit 1
 	fi
 
+	case "${OUI_PATH}" in
+	"${OUI_PATH0}" | "${OUI_PATH1}" | "${OUI_PATH2}") ;;
+	*)
+		if [ ! -d "${OUI_PATH0}" ]; then
+			ln -s ${OUI_PATH} ${OUI_PATH0}
+		fi ;;
+	esac
+
 	# Cleanup
-	rm -f ${OUI_IEEE}
+	rm -f ${AIRODUMP_NG_OUI}-old
 
 	echo "[*] Airodump-ng OUI file successfully updated"
 else

--- a/src/airodump-ng.c
+++ b/src/airodump-ng.c
@@ -4053,7 +4053,12 @@ int dump_write_kismet_netxml( void )
 						 st_cur->stmac[4], st_cur->stmac[5] );
 
 			/* Manufacturer, if set using standard oui list */
-			fprintf(G.f_kis_xml, "\t\t\t<client-manuf>%s</client-manuf>\n", (st_cur->manuf != NULL) ? st_cur->manuf : "Unknown");
+			manuf = NULL;
+			if (st_cur->manuf != NULL)
+				manuf = sanitize_xml((unsigned char *)st_cur->manuf, strlen(st_cur->manuf));
+			fprintf(G.f_kis_xml, "\t\t\t<client-manuf>%s</client-manuf>\n", (manuf != NULL) ? manuf : "Unknown");
+			if (manuf)
+				free(manuf);
 
 			/* Channel
 			   FIXME: Take G.freqoption in account */
@@ -6722,6 +6727,8 @@ usage:
         if ( G.output_format_pcap ||  G.f_cap != NULL ) fclose( G.f_cap );
         if ( G.f_ivs != NULL ) fclose( G.f_ivs );
     }
+    else
+        free(G.airodump_start_time);
 
     if( ! G.save_gps )
     {

--- a/src/airodump-ng.c
+++ b/src/airodump-ng.c
@@ -646,6 +646,7 @@ char usage[] =
 "      -x            <msecs> : Active Scanning Simulation\n"
 "      --manufacturer        : Display manufacturer from IEEE OUI list\n"
 "      --uptime              : Display AP Uptime from Beacon Timestamp\n"
+"      --wps                 : Display WPS information (if any)\n"
 "      --output-format\n"
 "                  <formats> : Output format. Possible values:\n"
 "                              pcap, ivs, csv, gps, kismet, netxml\n"
@@ -1417,9 +1418,15 @@ int dump_add_packet( unsigned char *h80211, int caplen, struct rx_info *ri, int 
 //         if(ap_cur->fcapt >= QLT_COUNT) update_rx_quality();
     }
 
-    if( h80211[0] == 0x80 )
+    switch( h80211[0] )
     {
-        ap_cur->nb_bcn++;
+        case  0x80:
+            ap_cur->nb_bcn++;
+        case  0x50:
+            /* reset the WPS state */
+            ap_cur->wps.state = 0xFF;
+            ap_cur->wps.ap_setup_locked = 0;
+            break;
     }
 
     ap_cur->nb_pkt++;
@@ -1829,6 +1836,54 @@ skip_probe:
             {
                 ap_cur->security |= STD_QOS;
                 p += length+2;
+            }
+            else if( (type == 0xDD && (length >= 4) && (memcmp(p+2, "\x00\x50\xF2\x04", 4) == 0)))
+            {
+                org_p = p;
+                p+=6;
+                int len = length, subtype = 0, sublen = 0;
+                while(len >= 4)
+                {
+                    subtype = (p[0] << 8) + p[1];
+                    sublen = (p[2] << 8) + p[3];
+                    if(sublen > len)
+                        break;
+                    switch(subtype)
+                    {
+                    case 0x104a: // WPS Version
+                        ap_cur->wps.version = p[4];
+                        break;
+                    case 0x1011: // Device Name
+                    case 0x1012: // Device Password ID
+                    case 0x1021: // Manufacturer
+                    case 0x1023: // Model
+                    case 0x1024: // Model Number
+                    case 0x103b: // Response Type
+                    case 0x103c: // RF Bands
+                    case 0x1041: // Selected Registrar
+                    case 0x1042: // Serial Number
+                        break;
+                    case 0x1044: // WPS State
+                        ap_cur->wps.state = p[4];
+                        break;
+                    case 0x1047: // UUID Enrollee
+                    case 0x1049: // Vendor Extension
+                    case 0x1054: // Primary Device Type
+                        break;
+                    case 0x1057: // AP Setup Locked
+                        ap_cur->wps.ap_setup_locked = p[4];
+                        break;
+                    case 0x1008: // Config Methods
+                    case 0x1053: // Selected Registrar Config Methods
+                        ap_cur->wps.meth = (p[4] << 8) + p[5];
+                        break;
+                    default:     // Unknown type-length-value
+                        break;
+                    }
+                    p += sublen+4;
+                    len -= sublen+4;
+                }
+                p = org_p + length+2;
             }
             else p += length+2;
         }
@@ -3091,6 +3146,22 @@ void dump_print( int ws_row, int ws_col, int if_num )
     if (G.show_uptime)
     	strcat(strbuf, "       UPTIME  ");
 
+    if (G.show_wps)
+    {
+        strcat(strbuf, "WPS   ");
+        if ( ws_col > (columns_ap - 4) )
+        {
+            memset(strbuf+columns_ap, 32, G.maxsize_wps_seen - 6 );
+            snprintf(strbuf+columns_ap+G.maxsize_wps_seen-6, 9,"%s","   ESSID");
+            if ( G.show_manufacturer  )
+            {
+                memset(strbuf+columns_ap+G.maxsize_wps_seen+2, 32, G.maxsize_essid_seen-5 );
+                snprintf(strbuf+columns_ap+G.maxsize_essid_seen-5, 15,"%s","  MANUFACTURER");
+            }
+        }
+    }
+    else
+    {
     strcat(strbuf, "ESSID");
 
 	if ( G.show_manufacturer && ( ws_col > (columns_ap - 4) ) ) {
@@ -3098,6 +3169,7 @@ void dump_print( int ws_row, int ws_col, int if_num )
 		memset(strbuf+columns_ap, 32, G.maxsize_essid_seen - 5 ); // 5 is the len of "ESSID"
 		snprintf(strbuf+columns_ap+G.maxsize_essid_seen-5, 15,"%s","  MANUFACTURER");
 	}
+    }
 
 	strbuf[ws_col - 1] = '\0';
 	fprintf( stderr, "%s\n", strbuf );
@@ -3269,13 +3341,64 @@ void dump_print( int ws_row, int ws_col, int if_num )
 	    if( ws_col > (columns_ap - 4) )
 	    {
 		memset( strbuf, 0, sizeof( strbuf ) );
+		if (G.show_wps)
+		{
+		    if (ap_cur->wps.state != 0xFF)
+		    {
+		        if (ap_cur->wps.ap_setup_locked) // AP setup locked
+		            snprintf(strbuf, sizeof(strbuf)-1, "Locked");
+		        else
+		        {
+		            snprintf(strbuf, sizeof(strbuf)-1, "%d.%d", ap_cur->wps.version >> 4, ap_cur->wps.version & 0xF); // Version
+		            if (ap_cur->wps.meth) // WPS Config Methods
+		            {
+		                char tbuf[64];
+		                memset( tbuf, '\0', sizeof(tbuf) );
+		                int sep = 0;
+#define T(bit, name) do {                       \
+    if (ap_cur->wps.meth & (1<<bit)) {          \
+        if (sep)                                \
+            strcat(tbuf, ",");                  \
+        sep = 1;                                \
+        strncat(tbuf, name, (64-strlen(tbuf))); \
+    } } while (0)
+		                T(0, "USB");     // USB method
+		                T(1, "ETHER");   // Ethernet
+		                T(2, "LAB");     // Label
+		                T(3, "DISP");    // Display
+		                T(4, "EXTNFC");  // Ext. NFC Token
+		                T(5, "INTNFC");  // Int. NFC Token
+		                T(6, "NFCINTF"); // NFC Interface
+		                T(7, "PBC");     // Push Button
+		                T(8, "KPAD");    // Keypad
+		                snprintf(strbuf+strlen(strbuf), sizeof(strbuf)-strlen(strbuf), " %s", tbuf);
+#undef T
+		            }
+		        }
+		    }
+		    else
+		        snprintf(strbuf, sizeof(strbuf)-1, " ");
+
+			if (G.maxsize_wps_seen <= strlen(strbuf))
+				G.maxsize_wps_seen = strlen(strbuf);
+			else // write spaces (32)
+				memset( strbuf+strlen(strbuf), 32,  (G.maxsize_wps_seen - strlen(strbuf))  );
+		}
 		if(ap_cur->essid[0] != 0x00)
 		{
+		    if (G.show_wps)
+		    snprintf( strbuf + G.maxsize_wps_seen, sizeof(strbuf)-G.maxsize_wps_seen,
+			    "  %s", ap_cur->essid );
+		    else
 		    snprintf( strbuf,  sizeof( strbuf ) - 1,
 			    "%s", ap_cur->essid );
 		}
 		else
 		{
+		    if (G.show_wps)
+		    snprintf( strbuf + G.maxsize_wps_seen, sizeof(strbuf)-G.maxsize_wps_seen,
+			    "  <length:%3d>%s", ap_cur->ssid_length, "\x00" );
+		    else
 		    snprintf( strbuf,  sizeof( strbuf ) - 1,
 			    "<length:%3d>%s", ap_cur->ssid_length, "\x00" );
 		}
@@ -5563,6 +5686,7 @@ int main( int argc, char *argv[] )
         {"ignore-negative-one", 0, &G.ignore_negative_one, 1},
         {"manufacturer",  0, 0, 'M'},
         {"uptime",   0, 0, 'U'},
+        {"wps",  0, 0, 'W'},
         {0,          0, 0,  0 }
     };
 
@@ -5632,8 +5756,10 @@ int main( int argc, char *argv[] )
     G.show_ack     =  0;
     G.hide_known   =  0;
     G.maxsize_essid_seen  =  5; // Initial value: length of "ESSID"
+    G.maxsize_wps_seen  =  6;
     G.show_manufacturer = 0;
     G.show_uptime  = 0;
+    G.show_wps     = 0;
     G.hopfreq      =  DEFAULT_HOPFREQ;
     G.s_file       =  NULL;
     G.s_iface      =  NULL;
@@ -5728,7 +5854,7 @@ int main( int argc, char *argv[] )
         option_index = 0;
 
         option = getopt_long( argc, argv,
-                        "b:c:egiw:s:t:u:m:d:N:R:aHDB:Ahf:r:EC:o:x:MU",
+                        "b:c:egiw:s:t:u:m:d:N:R:aHDB:Ahf:r:EC:o:x:MUW",
                         long_options, &option_index );
 
         if( option < 0 ) break;
@@ -5786,6 +5912,11 @@ int main( int argc, char *argv[] )
 	    case 'U' :
 	    		G.show_uptime = 1;
 	    		break;
+
+            case 'W':
+
+                G.show_wps = 1;
+                break;
 
             case 'c' :
 
@@ -6139,6 +6270,9 @@ usage:
         printf("\"%s --help\" for help.\n", argv[0]);
         return( 1 );
     }
+
+    if (G.show_wps && G.show_manufacturer)
+        G.maxsize_essid_seen += G.maxsize_wps_seen;
 
     if(G.s_iface != NULL)
     {

--- a/src/airodump-ng.h
+++ b/src/airodump-ng.h
@@ -158,6 +158,9 @@ const char *OUI_PATHS[] = {
 
 #define MIN_RAM_SIZE_LOAD_OUI_RAM 32768
 
+#define MAC_LEN 18
+// MAC address in hex colon representation and the additional \0.
+
 int read_pkts=0;
 
 int abg_chans [] =
@@ -198,6 +201,12 @@ struct oui {
 	char id[9]; /* TODO: Don't use ASCII chars to compare, use unsigned char[3] (later) with the value (hex ascii will have to be converted) */
 	char manuf[128]; /* TODO: Switch to a char * later to improve memory usage */
 	struct oui *next;
+};
+
+struct ethers_names {
+    unsigned char mac[6];
+    char name[MAC_LEN]; /* Name for the MAC address or device. */
+    struct ethers_names *next;
 };
 
 /* WPS_info struct */
@@ -314,6 +323,7 @@ struct NA_info
     struct NA_info *next;    /* the next client in list   */
     time_t tinit, tlast;     /* first and last time seen  */
     unsigned char namac[6];  /* the stations MAC address  */
+    char *manuf;             /* the stations manufacturer */
     int power;               /* last signal power         */
     int channel;             /* captured on channel       */
     int ack;                 /* number of ACK frames      */
@@ -333,6 +343,7 @@ struct globals
     struct ST_info *st_1st, *st_end;
     struct NA_info *na_1st, *na_end;
     struct oui *manufList;
+    struct ethers_names *ethersList;
 
     unsigned char prev_bssid[6];
     unsigned char f_bssid[6];
@@ -429,6 +440,8 @@ struct globals
 
     int hopfreq;
 
+    char*   s_ethers;       /* source file to define mappings from MAC to name
+                             * like /etc/ethers */
     char*   s_file;         /* source file to read packets */
     char*   s_iface;        /* source interface to read from */
     FILE *f_cap_in;
@@ -471,7 +484,9 @@ struct globals
     u_int maxsize_essid_seen;
     u_int maxsize_wps_seen;
     int show_manufacturer;
+    int show_ethers_name;
     int show_uptime;
+    int show_manufacturer_prefix;
     int show_wps;
 }
 G;

--- a/src/airodump-ng.h
+++ b/src/airodump-ng.h
@@ -200,6 +200,14 @@ struct oui {
 	struct oui *next;
 };
 
+/* WPS_info struct */
+struct WPS_info {
+    unsigned char version;    /* WPS Version */
+    unsigned char state;      /* Current WPS state */
+    unsigned char ap_setup_locked; /* AP setup locked */
+    unsigned int meth;        /* WPS Config Methods */
+};
+
 /* linked list of detected access points */
 struct AP_info
 {
@@ -269,6 +277,7 @@ struct AP_info
 					  
     int marked;
     int marked_color;
+    struct WPS_info wps;
 };
 
 /* linked list of detected clients */
@@ -460,8 +469,10 @@ struct globals
 
     int ignore_negative_one;
     u_int maxsize_essid_seen;
+    u_int maxsize_wps_seen;
     int show_manufacturer;
     int show_uptime;
+    int show_wps;
 }
 G;
 


### PR DESCRIPTION
I made some changes based on https://github.com/aircrack-ng/aircrack-ng/pull/11 and iw print_wifi_wps. Please review.
