### PR TITLE
-J option (convert .cap to .hccap) had random data in output

### DIFF
--- a/src/aircrack-ng.c
+++ b/src/aircrack-ng.c
@@ -4484,6 +4484,8 @@ int do_make_hccap(struct AP_info *ap_cur)
 
 	hccap_t hccap;
 
+	memset (&hccap, 0, sizeof (hccap));
+
 	memcpy (&hccap.essid,      &ap_cur->essid,          sizeof (ap_cur->essid));
 	memcpy (&hccap.mac1,       &ap_cur->bssid,          sizeof (ap_cur->bssid));
 	memcpy (&hccap.mac2,       &ap_cur->wpa.stmac,      sizeof (ap_cur->wpa.stmac));


### PR DESCRIPTION
This patch fixes a (what appeared to be a random) problem with .cap to *hashcat's .hccap format conversion.

The main problem here is basically that the struct was not zeroed and hence random data could end up in the output file.

But more specifically what happens is that while it is true that each entry of the .hccap struct was correctly filled (see https://hashcat.net/wiki/doku.php?id=hccap), the copying from the variable  struct AP_info *ap_cur to hccap_t hccap has several struct entries that do not have (exactly) the same type.
One simple example (but unlikely/not necessarily the only one) would be for instance this "copy" function call:
memcpy (&hccap.keyver,     &ap_cur->wpa.keyver,     sizeof (ap_cur->wpa.keyver));

While sizeof (ap_cur->wpa.keyver) == 1 (uint8_t see src/include/eapol.h), sizeof (hccap.keyver) == 4 (int32_t/int).
This implies that we only copy 1 "byte" (8 bits) to the hccap_t hccap variable, the other 3 bytes are neither zeroed, nor overwritten by memcpy or elsehow in the code.

The initial zeroing w/ memset () seems to fix a lot of this cases in my tests, but still the implicit covertion of different signesses and variabe size could in some cases still be a problem.

I can list examples what could happen if no zeroing of the hccap variable is done. For instance, let's assume that we want to recover a password of a WPA (1) network and let's assume that we have the case mentioned above (copy only 1 byte of 4) and also that the other 3 bytes of hccap.keyver  contain (without zeroing) random data (let us assume that at least 1 of the 3  "remaining" bytes are all different from 0). Since *Hashcat currently assumes that whenever the hccap.keyver is different from 1, wpa2 should be used, any of the 3 bytes (if different from 0) would trigger oclHashcat to assume it should try to crack the .hccap files with WPA2 (but remember we have a WPA 1 network here).
There were other such cases (with different struct hccap_t entries) that we could reproduce.
But good news, this fix seems to fix them all.

Greetings from the hashcat's devs
philsmd
