### PR TITLE
Match malloc sizeof parameter with actual usage.

### DIFF
--- a/src/aircrack-ng.c
+++ b/src/aircrack-ng.c
@@ -4840,7 +4840,7 @@ static int crack_wep_ptw(struct AP_info *ap_cur)
 
     opt.ap = ap_cur;
 
-    all = malloc(256*32*sizeof(int));
+    all = malloc(32*sizeof(int [256]));
     if (all == NULL) {
     	return FAILURE;
     }


### PR DESCRIPTION
Compiling with clang gives the following warning:

aircrack-ng.c:4843:11: warning: Result of 'malloc' is converted to a pointer of type 'int [256]', which is incompatible with sizeof operand type 'int *'

```
all = malloc(256*32*sizeof(int*));
```
