### PR TITLE
Add OSX support on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,14 @@
+os:
+    - linux
+    - osx
+
 language: c
+
 sudo: false
+
+before_install:
+    - if [ "$TRAVIS_OS_NAME" == "osx" ]; then (brew update && brew install libgcrypt sqlite3); fi
+
 addons:
   apt:
     packages:
@@ -11,7 +20,25 @@ addons:
     - libssl-dev
     - libnl-genl-3-dev
     - libpcre3-dev
+
 compiler:
   - gcc
   - clang
-script: make sqlite=true experimental=true && make check sqlite=true experimental=true && make clean && make sqlite=true experimental=true gcrypt=true && make check sqlite=true experimental=true gcrypt=true && make pcre=true && make check pcre=true && CFLAGS="-g -W -Wall -O0" make sqlite=true experimental=true && CFLAGS="-g -W -Wall -O0" make check sqlite=true experimental=true && make clean && CFLAGS="-g -W -Wall -O0" make sqlite=true experimental=true gcrypt=true && CFLAGS="-g -W -Wall -O0" make check sqlite=true experimental=true gcrypt=true && CFLAGS="-g -W -Wall -O0" make pcre=true && CFLAGS="-g -W -Wall -O0" make check pcre=true
+
+cache:
+    - ccache
+    - apt
+
+script:
+    - make sqlite=true experimental=true && make check sqlite=true experimental=true && make clean
+    - make sqlite=true experimental=true gcrypt=true && make check sqlite=true experimental=true gcrypt=true
+    - make pcre=true && make check pcre=true
+    - export CFLAGS="-g -W -Wall -O0"
+    - make sqlite=true experimental=true && make check sqlite=true experimental=true && make clean
+    - make sqlite=true experimental=true gcrypt=true && make check sqlite=true experimental=true gcrypt=true
+    - make pcre=true && make check pcre=true
+
+notifications:
+    irc: "chat.freenode.net#aircrack-ng-test"
+    on_success: never
+    on_failure: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,6 @@ compiler:
   - gcc
   - clang
 
-cache:
-    - ccache
-    - apt
-
 script:
     - make sqlite=true experimental=true && make check sqlite=true experimental=true && make clean
     - make sqlite=true experimental=true gcrypt=true && make check sqlite=true experimental=true gcrypt=true
@@ -37,8 +33,3 @@ script:
     - make sqlite=true experimental=true && make check sqlite=true experimental=true && make clean
     - make sqlite=true experimental=true gcrypt=true && make check sqlite=true experimental=true gcrypt=true
     - make pcre=true && make check pcre=true
-
-notifications:
-    irc: "chat.freenode.net#aircrack-ng-test"
-    on_success: never
-    on_failure: always

--- a/common.mak
+++ b/common.mak
@@ -137,7 +137,7 @@ ifeq ($(OSNAME), OpenBSD)
 	CXXFLAGS	= $(CFLAGS) -fdata-sections -ffunction-sections
 else
 	INTEL_ASM	= $(shell echo | gcc -fsyntax-only -masm=intel -xc - 2>/dev/null && echo Y)
-ifeq ($INTEL_ASM), Y)
+ifeq ($(INTEL_ASM), Y)
 	ASM_FLAG	= -masm=intel
 endif
 	CXXFLAGS	= $(CFLAGS) $(ASMFLAG) -fdata-sections -ffunction-sections

--- a/src/sha1-sse2.S
+++ b/src/sha1-sse2.S
@@ -523,10 +523,17 @@ cpuid_exit:
 		ret
 #ifdef __i386__
 #ifdef __PIC__
+#ifndef __APPLE__
 	.section .gnu.linkonce.t.__i686.get_pc_thunk.bx,"ax",@progbits
+#endif
 .globl __i686.get_pc_thunk.bx
+
+#ifdef __APPLE__
+    .private_extern  __i686.get_pc_thunk.bx
+#else
 	.hidden  __i686.get_pc_thunk.bx
 	.type    __i686.get_pc_thunk.bx,@function
+#endif
 __i686.get_pc_thunk.bx:
 	movl (%esp), %ebx
 	ret

--- a/test/test-airdecap-ng.sh
+++ b/test/test-airdecap-ng.sh
@@ -3,7 +3,21 @@
 # Carlos Alberto Lopez Perez <clopez@igalia.com>
 # Thomas d'Otreppe <tdotreppe@aircrack-ng.org> - Support for sha1 and sh
 TESTDIR="$(dirname $0)"
-tmpdir="$(mktemp -d)"
+tmpdir="$(mktemp -d tmp.XXXXXXXXXX)"
+
+compute_sha1() {
+    if type "sha1sum" > /dev/null 2>/dev/null ; then
+        sha1sum "${1}" | awk '{print $1}'
+    elif type "shasum" > /dev/null 2>/dev/null ; then
+        shasum "${1}" | awk '{print $1}'
+    elif type "sha1" > /dev/null 2>/dev/null ; then
+        sha1 -q "${1}"
+    else
+        echo "Unable to find something to compute sha1" 1>&2
+    fi
+ }
+
+
 # Clean on exit
 trap "rm -fr "${tmpdir}"" SIGINT SIGKILL SIGQUIT SIGSEGV SIGPIPE SIGALRM SIGTERM EXIT
 # Test1
@@ -11,16 +25,10 @@ cp -f "${TESTDIR}/wpa.cap" "${tmpdir}"
 ./airdecap-ng -e test -p biscotte "${tmpdir}/wpa.cap" | \
         grep "Number of decrypted WPA  packets         2" || exit 1
 [ $? -ne 0 ] && exit 1
-# Check that the hash is what we expect.
-# For each hash there are two possibilities: little or big endian
-if ! type "sha1sum" > /dev/null 2>/dev/null ; then
-        sha1sum=$(sha1 -q "${tmpdir}/wpa-dec.cap")
-else
-        sha1sum=$(sha1sum "${tmpdir}/wpa-dec.cap" | awk '{print $1}')
-fi
+result=$(compute_sha1 "${tmpdir}/wpa-dec.cap")
 
-if [ "${sha1sum}" != "69f8557cf96a26060989e88adfb521a01fc9b122" ] &&
-        [ "${sha1sum}" != "fb1592b2c0dccef542c1f46297394ee2892f8ed3" ]; then
+if [ "${result}" != "69f8557cf96a26060989e88adfb521a01fc9b122" ] &&
+        [ "${result}" != "fb1592b2c0dccef542c1f46297394ee2892f8ed3" ]; then
         exit 1
 fi
 
@@ -29,14 +37,10 @@ cp -f "${TESTDIR}/wpa-psk-linksys.cap" "${tmpdir}"
 ./airdecap-ng -e linksys -p dictionary "${tmpdir}/wpa-psk-linksys.cap" | \
         grep "Number of decrypted WPA  packets        53"
 [ $? -ne 0 ] && exit 1
-if ! type "sha1sum" > /dev/null 2>/dev/null ; then
-        sha1sum=$(sha1 -q "${tmpdir}/wpa-psk-linksys-dec.cap")
-else
-        sha1sum=$(sha1sum "${tmpdir}/wpa-psk-linksys-dec.cap" | awk '{print $1}')
-fi
+result=$(compute_sha1 "${tmpdir}/wpa-psk-linksys-dec.cap")
 
-if [ "${sha1sum}" != "1e75a9af0d9703c4ae4fc8ea454326aeb4abecc1" ] &&
-        [ "${sha1sum}"  != "1c3c4123ba6718bd3db66de251a125ed65cd6ee6" ]; then
+if [ "${result}" != "1e75a9af0d9703c4ae4fc8ea454326aeb4abecc1" ] &&
+        [ "${result}"  != "1c3c4123ba6718bd3db66de251a125ed65cd6ee6" ]; then
         exit 1
 fi
 
@@ -45,14 +49,10 @@ cp -f "${TESTDIR}/wpa2-psk-linksys.cap" "${tmpdir}"
 ./airdecap-ng -e linksys -p dictionary "${tmpdir}/wpa2-psk-linksys.cap" | \
         grep "Number of decrypted WPA  packets        25"
 [ $? -ne 0 ] && exit 1
-if ! type "sha1sum" > /dev/null 2>/dev/null ; then
-        sha1sum=$(sha1 -q "${tmpdir}/wpa2-psk-linksys-dec.cap")
-else
-        sha1sum=$(sha1sum "${tmpdir}/wpa2-psk-linksys-dec.cap" | awk '{print $1}')
-fi
+result=$(compute_sha1 "${tmpdir}/wpa2-psk-linksys-dec.cap")
 
-if [ "${sha1sum}" != "2da107b96fbe19d926020ffb0da72553b18a5775" ] &&
-        [ "${sha1sum}" != "dc7d033b9759838d57b74db04185c3586cbd8042" ]; then
+if [ "${result}" != "2da107b96fbe19d926020ffb0da72553b18a5775" ] &&
+        [ "${result}" != "dc7d033b9759838d57b74db04185c3586cbd8042" ]; then
         exit 1
 fi
 exit 0

--- a/test/test-airolib-sqlite.sh
+++ b/test/test-airolib-sqlite.sh
@@ -9,7 +9,7 @@
 set -e
 set -o pipefail
 TESTDIR="$(dirname $0)"
-tmpfile="$(mktemp -u)"
+tmpfile="$(mktemp -u tmp.XXXXXXXXXX)"
 # Clean on exit
 trap "rm -f "${tmpfile}"" SIGINT SIGKILL SIGQUIT SIGSEGV SIGPIPE SIGALRM SIGTERM EXIT
 echo Harkonen | ./airolib-ng "${tmpfile}" --import essid -


### PR DESCRIPTION
- Add OSX as a target in `.travis.yml`
- Remove the unsupported `-masm=intel` flag in the Makefile for OSX only
- Translate conditionally some Gnu-ism into OSX-ism in the asm implementation of sha1
- Fix some non portable `mktemp` invocation
- OSX has `shasum` instead of `sha1sum` or `sha1`

I also added some caching to travis.
