### PR TITLE
Fix #48: 'wi_read(): No child processes' error

### DIFF
--- a/src/besside-ng.c
+++ b/src/besside-ng.c
@@ -2551,7 +2551,7 @@ static void wifi_read(void)
 	struct network *n;
 
 	rd = wi_read(s->s_wi, buf, sizeof(buf), &ri);
-	if (rd <= 0)
+	if (rd < 0)
 		err(1, "wi_read()");
 
 	s->s_ri = &ri;


### PR DESCRIPTION
When running `besside-ng`, I often encountered `wi_read(): No child processes` on startup. This one character change fixes the issue. I traced `wi_read()`'s execution to `file_read()` in `file.c`. That function returns the length of bytes read. If zero bytes were read, that's not an error.

Or at least... I don't think it is. Honestly, I haven't explored this codebase at all, so my understanding is rather superficial. I just wanted to get things working for me, and it looks like this change will help others.
