### PR TITLE
airodump-ng: also set the channel from ht information -> primary channel if exists

### DIFF
--- a/src/airodump-ng.c
+++ b/src/airodump-ng.c
@@ -1751,6 +1751,10 @@ skip_probe:
 
             if( p[0] == 0x03 )
                 ap_cur->channel = p[2];
+            /* also get the channel from ht information->primary channel */
+            else if (p[0] == 0x3d){
+                ap_cur->channel = p[2];
+            }
 
             p += 2 + p[1];
         }


### PR DESCRIPTION
After working with many 5ghz routers i noticed that channel was stuck at -1. I checked the beacon packets from those routers and noticed that many of them don't have the DS Parameter Set tag but instead they have the HT Information which contains the channel. Some may have both, so the current change sets the channel of a station from HT Information tag only if DS Parameter Set tag doesn't exist.
