### PR TITLE
Remove bashisms

### DIFF
--- a/scripts/airodump-ng-oui-update
+++ b/scripts/airodump-ng-oui-update
@@ -29,9 +29,9 @@ then
 	USERID="`id -u 2> /dev/null`"
 fi
 
-if [ x$USERID = "x" -a x$UID != "x" ]
+if [ x$USERID = "x" -a x$(id -ru) != "x" ]
 then
-	USERID=$UID
+	USERID=$(id -ru)
 fi
 
 if [ x$USERID != "x" -a x$USERID != "x0" ]


### PR DESCRIPTION
There's still this one left, but i'm not really sure if its a false positive or how to fix it.

```
samueloph@deb:~/Documents/aircrack-ng/scripts$ checkbashisms *
possible bashism in airmon-ng line 1271 (sh --long-option):
        if $SHELL --version > /dev/null 2>&1
```
