### PR TITLE
Fix typos

### DIFF
--- a/manpages/airdecap-ng.1
+++ b/manpages/airdecap-ng.1
@@ -7,7 +7,7 @@ airdecap-ng - decrypt a WEP/WPA crypted pcap file
 [options] <pcap file>
 .SH DESCRIPTION
 .BI airdecap-ng
-decrypts a WEP/WPA crypted pcap file to a uncrypted one by using the right WEP/WPA keys.
+decrypts a WEP/WPA crypted pcap file to a unencrypted one by using the right WEP/WPA keys.
 .SH OPTIONS
 .TP
 .I -H, --help

--- a/src/airolib-ng.c
+++ b/src/airolib-ng.c
@@ -974,7 +974,7 @@ int main(int argc, char **argv) {
 				// Import
 
 				if (argc < 5) {
-					print_help("You must specifiy an import format and a file.");
+					print_help("You must specify an import format and a file.");
 				} else if (strcasecmp(argv[3], IMPORT_COWPATTY) == 0) {
 					if ( check_for_db(&db, argv[1], 1, 0) ) {
 						return 1;

--- a/src/easside-ng.c
+++ b/src/easside-ng.c
@@ -524,7 +524,7 @@ void read_auth(struct east_state *es, struct ieee80211_frame *wh, int len)
 
 	sp++;
 	if (le16toh(*sp) != 0) {
-		printf("Auth unsuccesful %d\n", le16toh(*sp));
+		printf("Auth unsuccessful %d\n", le16toh(*sp));
 		exit(1);
 	}
 

--- a/src/tkiptun-ng.c
+++ b/src/tkiptun-ng.c
@@ -166,7 +166,7 @@ char usage[] =
 "      -c dmac   : set Destination  MAC address\n"
 "      -h smac   : set Source       MAC address\n"
 "      -e essid  : set target AP SSID\n"
-"      -M sec    : MIC error timout in seconds [60]\n"
+"      -M sec    : MIC error timeout in seconds [60]\n"
 "\n"
 "  Debug options:\n"
 "\n"


### PR DESCRIPTION
This is part 2 of https://github.com/aircrack-ng/aircrack-ng/pull/78.

These typos were reported by the packaging tools on Debian while i was preparing the rc4's package.

Thanks.
