### PR TITLE
Remove useless not null check

### DIFF
--- a/src/airodump-ng.c
+++ b/src/airodump-ng.c
@@ -7404,10 +7404,7 @@ usage:
     {
 		// Freeing AP List
         ap_next = ap_cur->next;
-
-        if( ap_cur != NULL )
-            free(ap_cur);
-
+        free(ap_cur);
         ap_cur = ap_next;
     }
 


### PR DESCRIPTION
We already made sure that ap_cur is not NULL inside while. No need to check it again before freeing the memory.