### PR TITLE
Fix build on OSX for OpenSSL

### DIFF
--- a/common.mak
+++ b/common.mak
@@ -40,14 +40,17 @@ endif
 endif
 
 COMMON_CFLAGS	=
+OSX_ALT_FLAGS	=
 
 ifeq ($(subst TRUE,true,$(filter TRUE true,$(xcode) $(XCODE))),true)
 	COMMON_CFLAGS	+= -I/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-migrator/sdk/MacOSX.sdk/usr/include/ -D_XCODE -I../..
+	OSX_ALT_FLAGS	= true
 endif
 
 ifeq ($(subst TRUE,true,$(filter TRUE true,$(macport) $(MACPORT))),true)
 	COMMON_CFLAGS	+= -I/opt/local/include -I../..
 	LDFLAGS		+= -L/opt/local/lib
+	OSX_ALT_FLAGS	= true
 endif
 
 ifeq ($(subst TRUE,true,$(filter TRUE true,$(sqlite) $(SQLITE))),true)

--- a/src/Makefile
+++ b/src/Makefile
@@ -127,9 +127,15 @@ ifeq ($(subst TRUE,true,$(filter TRUE true,$(gcrypt) $(GCRYPT))),true)
 	OBJS_TT		+= sha1-git.o
 	OBJS_BS		+= sha1-git.o
 else
+	ifeq ($(OSNAME), Darwin)
+		ifneq ($(OSX_ALT_FLAGS), true)
+			CFLAGS		+= -I/usr/local/opt/openssl/include
+			LDFLAGS		+= -L/usr/local/opt/openssl/lib
+		endif
+	endif
+
 	LIBSSL		= -lssl -lcrypto $(LDFLAGS)
 endif
-
 
 ifeq ($(subst TRUE,true,$(filter TRUE true,$(sqlite) $(SQLITE))),true)
 	LIBSQL		= -L/usr/local/lib -lsqlite3

--- a/test/cryptounittest/Makefile
+++ b/test/cryptounittest/Makefile
@@ -15,6 +15,13 @@ ifeq ($(subst TRUE,true,$(filter TRUE true,$(gcrypt) $(GCRYPT))),true)
 	LIBSSL          =  -lgcrypt $(LDFLAGS)
 	CFLAGS          += -DUSE_GCRYPT
 else
+	ifeq ($(OSNAME), Darwin)
+		ifneq ($(OSX_ALT_FLAGS), true)
+			CFLAGS      += -I/usr/local/opt/openssl/include
+			LDFLAGS     += -L/usr/local/opt/openssl/lib
+		endif
+	endif
+
 	LIBSSL          = -lssl -lcrypto $(LDFLAGS)
 endif
 


### PR DESCRIPTION
Those green ✓ are so much better than red ❌. I've added a patch to fix the Travis builds on OSX. Also tested it on Mac / El Capitan, it builds and passes checks fine both with and without xcode=true option.

In common.mak we define a variable OSX_ALT_FLAGS, which we set to true if we do "make ... macport=true" or "make ... xcode = true". Later we check if that flag is set to true, and if so - do nothing, because macport and xcode make options add their own stuff.

In files src/Makefile and test/cryptounittest/Makefile there are checks if gcrypt is used. If it is not used, then OpenSSL is used. There I've added a check if we're on Darwin and OSX_ALT_FLAGS is not true , then we add following:
```
CFLAGS		+= -I/usr/local/opt/openssl/include
LDFLAGS	+= -L/usr/local/opt/openssl/lib
```
(These are suggested by 'brew install openssl')