### PR TITLE
Fix format specifiers part2

### DIFF
--- a/src/airdecap-ng.c
+++ b/src/airdecap-ng.c
@@ -646,7 +646,7 @@ usage:
         {
             /* update the status line every second */
 
-            printf( "\33[KRead %ld packets...\r", stats.nb_read );
+            printf( "\33[KRead %lu packets...\r", stats.nb_read );
             fflush( stdout );
             tt = time( NULL );
         }
@@ -1055,13 +1055,13 @@ usage:
 
     /* write some statistics */
 
-    printf( "\33[KTotal number of packets read      % 8ld\n"
-                 "Total number of WEP data packets  % 8ld\n"
-                 "Total number of WPA data packets  % 8ld\n"
-                 "Number of plaintext data packets  % 8ld\n"
-                 "Number of decrypted WEP  packets  % 8ld\n"
-                 "Number of corrupted WEP  packets  % 8ld\n"
-                 "Number of decrypted WPA  packets  % 8ld\n",
+    printf( "\33[KTotal number of packets read      % 8lu\n"
+                 "Total number of WEP data packets  % 8lu\n"
+                 "Total number of WPA data packets  % 8lu\n"
+                 "Number of plaintext data packets  % 8lu\n"
+                 "Number of decrypted WEP  packets  % 8lu\n"
+                 "Number of corrupted WEP  packets  % 8lu\n"
+                 "Number of decrypted WPA  packets  % 8lu\n",
             stats.nb_read, stats.nb_wep, stats.nb_wpa,
             stats.nb_plain, stats.nb_unwep, stats.nb_bad, stats.nb_unwpa );
 

--- a/src/airdecloak-ng.c
+++ b/src/airdecloak-ng.c
@@ -383,7 +383,7 @@ BOOLEAN read_packets(void)
 			puts("PPI");
 			break;
 		default:
-			printf("Unknown (%d)\n", _pfh_in.linktype);
+			printf("Unknown (%lu)\n", (unsigned long) _pfh_in.linktype);
 			break;
 	}
 
@@ -396,7 +396,7 @@ BOOLEAN read_packets(void)
         {
             // update the status line every second
 
-            printf( "\33[KRead %ld packets...\r", stats.nb_read );
+            printf( "\33[KRead %lu packets...\r", stats.nb_read );
             fflush( stdout );
             tt = time( NULL );
         }
@@ -427,7 +427,7 @@ BOOLEAN read_packets(void)
 
         if( _packet_elt_head->current->header.caplen <= 0 || _packet_elt_head->current->header.caplen > 65535 )
         {
-            printf( "Corrupted file? Invalid packet length %d.\n", _packet_elt_head->current->header.caplen );
+            printf( "Corrupted file? Invalid packet length %lu.\n", (unsigned long) _packet_elt_head->current->header.caplen );
             break;
         }
 
@@ -440,9 +440,9 @@ BOOLEAN read_packets(void)
 
         if( bytes_read != (size_t) _packet_elt_head->current->header.caplen )
         {
-			printf("Error reading the file: read %lu bytes out of %d.\n",
+			printf("Error reading the file: read %lu bytes out of %lu.\n",
 						(unsigned long) bytes_read,
-						_packet_elt_head->current->header.caplen);
+						(unsigned long) _packet_elt_head->current->header.caplen);
 
             break;
 		}

--- a/src/ivstools.c
+++ b/src/ivstools.c
@@ -203,7 +203,7 @@ int merge( int argc, char *argv[] )
         {
             nbw += n;
             unused = fwrite( buffer, 1, n, f_out );
-            printf( "%ld bytes written\r", nbw );
+            printf( "%lu bytes written\r", nbw );
         }
 
         fclose( f_in );
@@ -869,7 +869,7 @@ int main( int argc, char *argv[] )
     {
         if( time( NULL ) - tt > 0 )
         {
-            printf( "\33[KRead %ld packets...\r", nbr );
+            printf( "\33[KRead %lu packets...\r", nbr );
             fflush( stdout );
             tt = time( NULL );
         }
@@ -957,10 +957,10 @@ int main( int argc, char *argv[] )
     fclose( f_in );
     fclose( G.f_ivs );
 
-    printf( "\33[2KRead %ld packets.\n", nbr );
+    printf( "\33[2KRead %lu packets.\n", nbr );
 
     if ( nbivs > 0 )
-        printf( "Written %ld IVs.\n", nbivs);
+        printf( "Written %lu IVs.\n", nbivs);
     else
     {
         remove ( argv[3] );

--- a/src/osdep/file.c
+++ b/src/osdep/file.c
@@ -60,7 +60,7 @@ static int file_read(struct wif *wi, unsigned char *h80211, int len,
 		return -1;
 
 	if (pkh.caplen > sizeof(buf)) {
-		printf("Bad caplen %d\n", pkh.caplen);
+		printf("Bad caplen %lu\n", (unsigned long) pkh.caplen);
 		return 0;
 	}
 


### PR DESCRIPTION
Minor format specifiers for *printf fixes. Mostly %d/ld to %u/lu.
linktype and caplen are both uint32_t. Long is at least 32 bits, so it should always be safe to use %lu together with casting uint32_t vals to unsigned long.