### PR TITLE
Fix format specifiers part3

### DIFF
--- a/src/aircrack-ng.c
+++ b/src/aircrack-ng.c
@@ -1028,8 +1028,8 @@ void read_thread( void *arg )
 
 			if( pkh.caplen <= 0 || pkh.caplen > 65535 )
 			{
-				fprintf( stderr, "\nInvalid packet capture length %d - "
-					"corrupted file?\n", pkh.caplen );
+				fprintf( stderr, "\nInvalid packet capture length %lu - "
+					"corrupted file?\n", (unsigned long) pkh.caplen );
 				eof_wait( &eof_notified );
 				_exit( FAILURE );
 			}
@@ -1962,8 +1962,8 @@ void check_thread( void *arg )
 
 			if( pkh.caplen <= 0 || pkh.caplen > 65535 )
 			{
-				fprintf( stderr, "\nInvalid packet capture length %d - "
-					"corrupted file?\n", pkh.caplen );
+				fprintf( stderr, "\nInvalid packet capture length %lu - "
+					"corrupted file?\n", (unsigned long) pkh.caplen );
 				goto read_fail;
 			}
 

--- a/src/aireplay-ng.c
+++ b/src/aireplay-ng.c
@@ -2348,7 +2348,7 @@ read_packets:
         if( ticks[1] > (RTC_RESOLUTION/10) )
         {
             ticks[1] = 0;
-            printf( "\rSent %ld packets...(%d pps)\33[K\r", nb_pkt_sent, (int)((double)nb_pkt_sent/((double)ticks[0]/(double)RTC_RESOLUTION)));
+            printf( "\rSent %lu packets...(%d pps)\33[K\r", nb_pkt_sent, (int)((double)nb_pkt_sent/((double)ticks[0]/(double)RTC_RESOLUTION)));
             fflush( stdout );
         }
 
@@ -2515,7 +2515,7 @@ int do_attack_arp_resend( void )
         {
             ticks[1] = 0;
             printf( "\rRead %ld packets (got %ld ARP requests and %ld ACKs), "
-                    "sent %ld packets...(%d pps)\r",
+                    "sent %lu packets...(%d pps)\r",
                     nb_pkt_read, nb_arp_tot, nb_ack_pkt, nb_pkt_sent, (int)((double)nb_pkt_sent/((double)ticks[0]/(double)RTC_RESOLUTION)) );
             fflush( stdout );
         }
@@ -2951,7 +2951,7 @@ int do_attack_caffe_latte( void )
         {
             ticks[1] = 0;
             printf( "\rRead %ld packets (%ld ARPs, %ld ACKs), "
-                    "sent %ld packets...(%d pps)\r",
+                    "sent %lu packets...(%d pps)\r",
                     nb_pkt_read, nb_arp_tot, nb_ack_pkt, nb_pkt_sent, (int)((double)nb_pkt_sent/((double)ticks[0]/(double)RTC_RESOLUTION)) );
             fflush( stdout );
         }
@@ -3412,7 +3412,7 @@ int do_attack_migmode( void )
         {
             ticks[1] = 0;
             printf( "\rRead %ld packets (%ld ARPs, %ld ACKs), "
-                    "sent %ld packets...(%d pps)\r",
+                    "sent %lu packets...(%d pps)\r",
                     nb_pkt_read, nb_arp_tot, nb_ack_pkt, nb_pkt_sent, (int)((double)nb_pkt_sent/((double)ticks[0]/(double)RTC_RESOLUTION)) );
             fflush( stdout );
         }
@@ -4055,7 +4055,7 @@ read_packets:
         if( ticks[1] > (RTC_RESOLUTION/10) )
         {
             ticks[1] = 0;
-            printf( "\rSent %ld packets...(%d pps)\33[K\r", nb_pkt_sent, (int)((double)nb_pkt_sent/((double)ticks[0]/(double)RTC_RESOLUTION)));
+            printf( "\rSent %lu packets...(%d pps)\33[K\r", nb_pkt_sent, (int)((double)nb_pkt_sent/((double)ticks[0]/(double)RTC_RESOLUTION)));
             fflush( stdout );
         }
 
@@ -4354,7 +4354,7 @@ int do_attack_chopchop( void )
         if( ticks[1] > (RTC_RESOLUTION/10) )
         {
             ticks[1] = 0;
-            printf( "\rSent %3ld packets, current guess: %02X...\33[K",
+            printf( "\rSent %3lu packets, current guess: %02X...\33[K",
                     nb_pkt_sent, guess );
             fflush( stdout );
         }
@@ -4596,7 +4596,7 @@ int do_attack_chopchop( void )
         n = caplen - data_start;
 
         printf( "\rOffset %4d (%2d%% done) | xor = %02X | pt = %02X | "
-                "%4ld frames written in %5.0fms\n", data_end - 1,
+                "%4lu frames written in %5.0fms\n", data_end - 1,
                 100 * ( caplen - data_end ) / n,
                 chopped[data_end - 1],
                 chopped[data_end - 1] ^ srcbuf[data_end + srcdiff - 1],

--- a/src/besside-ng.c
+++ b/src/besside-ng.c
@@ -2647,7 +2647,7 @@ static void print_status(int advance)
 			speed_calculate(&n->n_flood_in);
 			speed_calculate(&n->n_flood_out);
 
-			printf(" - %d IVs rate %d [%d PPS out] len %d",
+			printf(" - %d IVs rate %u [%u PPS out] len %d",
 			       n->n_data_count,
 			       n->n_flood_in.s_speed,
 			       n->n_flood_out.s_speed,
@@ -3095,7 +3095,7 @@ static void print_state(int UNUSED(x))
 	}
 
 	printf("Current chan: %d\n", s->s_chan);
-	printf("Hop cycle %d chans:", s->s_hopcycles);
+	printf("Hop cycle %u chans:", s->s_hopcycles);
 	do {
 		printf(" %d", c->c_num);
 		c = c->c_next;

--- a/src/tkiptun-ng.c
+++ b/src/tkiptun-ng.c
@@ -2534,7 +2534,7 @@ int do_attack_tkipchop( unsigned char* src_packet, int src_packet_len )
         if( ticks[1] > (RTC_RESOLUTION/10) )
         {
             ticks[1] = 0;
-            printf( "\rSent %3ld packets, current guess: %02X...\33[K",
+            printf( "\rSent %3lu packets, current guess: %02X...\33[K",
                     nb_pkt_sent, guess );
             fflush( stdout );
         }
@@ -2829,7 +2829,7 @@ int do_attack_tkipchop( unsigned char* src_packet, int src_packet_len )
         n = caplen - data_start;
 
         printf( "\r"); PCT; printf("Offset %4d (%2d%% done) | xor = %02X | pt = %02X | "
-                "%4ld frames written in %5.0fms\n", data_end - 1,
+                "%4lu frames written in %5.0fms\n", data_end - 1,
                 100 * ( caplen - data_end ) / n,
                 chopped[data_end - 1],
                 chopped[data_end - 1] ^ srcbuf[data_end - 1],


### PR DESCRIPTION
Minor format specifiers for *printf fixes. Mostly %d/ld to %u/lu.
caplen is uint32_t. Long is at least 32 bits, so it should always be safe to use %lu together with casting uint32_t vals to unsigned long.