### PR TITLE
HostAPd-WPE patch: fix challenge_hash when user starts with "domain\"

### DIFF
--- a/patches/wpe/hostapd-wpe/hostapd-wpe.patch
+++ b/patches/wpe/hostapd-wpe/hostapd-wpe.patch
@@ -3661,8 +3661,8 @@ diff -rupN hostapd-2.6/src/eap_server/eap_server.c hostapd-2.6-wpe/src/eap_serve
  				       identity_len, phase2, user) != 0) {
  		eap_user_free(user);
 diff -rupN hostapd-2.6/src/eap_server/eap_server_mschapv2.c hostapd-2.6-wpe/src/eap_server/eap_server_mschapv2.c
---- hostapd-2.6/src/eap_server/eap_server_mschapv2.c	2016-10-02 14:51:11.000000000 -0400
-+++ hostapd-2.6-wpe/src/eap_server/eap_server_mschapv2.c	2016-11-06 18:19:15.675651156 -0500
+--- hostapd-2.6/src/eap_server/eap_server_mschapv2.c	2016-10-02 20:51:11.000000000 +0200
++++ hostapd-2.6-wpe/src/eap_server/eap_server_mschapv2.c	2016-12-07 15:49:05.525550618 +0100
 @@ -12,7 +12,7 @@
  #include "crypto/ms_funcs.h"
  #include "crypto/random.h"
@@ -3681,15 +3681,15 @@ diff -rupN hostapd-2.6/src/eap_server/eap_server_mschapv2.c hostapd-2.6-wpe/src/
  	pos = eap_hdr_validate(EAP_VENDOR_IETF, EAP_TYPE_MSCHAPV2, respData,
  			       &len);
  	if (pos == NULL || len < 1)
-@@ -329,6 +329,8 @@ static void eap_mschapv2_process_respons
- 	wpa_hexdump(MSG_MSGDUMP, "EAP-MSCHAPV2: NT-Response", nt_response, 24);
- 	wpa_printf(MSG_MSGDUMP, "EAP-MSCHAPV2: Flags 0x%x", flags);
- 	wpa_hexdump_ascii(MSG_MSGDUMP, "EAP-MSCHAPV2: Name", name, name_len);
-+	challenge_hash(peer_challenge, data->auth_challenge, name, name_len, wpe_challenge_hash);
+@@ -372,6 +372,8 @@ static void eap_mschapv2_process_respons
+ 		}
+ 	}
+ #endif /* CONFIG_TESTING_OPTIONS */
++	challenge_hash(peer_challenge, data->auth_challenge, username, username_len, wpe_challenge_hash);
 +	wpe_log_chalresp("mschapv2", name, name_len, wpe_challenge_hash, 8, nt_response, 24);
  
- 	buf = os_malloc(name_len * 4 + 1);
- 	if (buf) {
+ 	if (username_len != user_len ||
+ 	    os_memcmp(username, user, username_len) != 0) {
 @@ -406,6 +408,11 @@ static void eap_mschapv2_process_respons
  		return;
  	}


### PR DESCRIPTION
This patch is similar to @Rogdham https://github.com/OpenSecurityResearch/hostapd-wpe/pull/4
"username" was correctly used instead of "user", but it was not yet defined so random/uninitialized data was used instead of the real username, without the "domain\" part. This is confirmed by compilation warnings stating that "username(_len) may be used uninitialized".
![2016-12-07_14-59-42](https://cloud.githubusercontent.com/assets/550823/21013824/bab12248-bd5b-11e6-86c3-73769d01a148.png)

I have just moved down the two lines with challenge_hash() and wpe_log_chalresp(), after the "username" var is set and modified to remove the "domain\" part.

I have tested my patch with known credentials (both with and without the domain part to be sure to prevent regression).

John is unable to crack the following NETNTLM hashes generated with the current code:
```
mschapv2: Wed Dec  7 15:42:05 2016
	 username:	dom\user
	 challenge:	3b:9b:4b:54:f6:05:e3:5b
	 response:	bf:85:36:6c:ce:1b:7f:3c:28:55:b9:19:6d:94:33:d1:c8:54:5f:9f:05:9b:80:f0
	 jtr NETNTLM:	dom\user:$NETNTLM$3b9b4b54f605e35b$bf85366cce1b7f3c2855b9196d9433d1c8545f9f059b80f0
```
```
mschapv2: Wed Dec  7 15:45:45 2016
	 username:	user
	 challenge:	00:b5:35:ad:96:5c:bf:78
	 response:	a2:89:7a:27:78:e6:f4:fc:49:4b:e4:03:55:02:4e:60:c5:4e:73:44:21:4d:a4:64
	 jtr NETNTLM:	user:$NETNTLM$00b535ad965cbf78$a2897a2778e6f4fc494be40355024e60c54e7344214da464
```
asleap is also unable to crack the C/R with the well-known message "Could not recover last 2 bytes of hash from the challenge/response.  Sorry it didn't work out."

And John successfully cracks the following hashes (password is "test") generated with my patch:
```
mschapv2: Wed Dec  7 15:46:17 2016
	 username:	user
	 challenge:	54:c6:0d:f1:94:d8:93:b1
	 response:	91:8e:2a:a0:0c:3d:e1:38:ed:a6:66:ea:5f:00:5a:fa:7c:d1:0c:1b:2d:76:0d:26
	 jtr NETNTLM:	user:$NETNTLM$54c60df194d893b1$918e2aa00c3de138eda666ea5f005afa7cd10c1b2d760d26
```
```
mschapv2: Wed Dec  7 15:42:53 2016
	 username:	dom\user
	 challenge:	3a:6f:d9:22:70:13:e3:4a
	 response:	a0:29:1f:3e:34:8f:70:7f:dd:43:42:16:93:eb:81:b3:bb:31:31:0c:c5:38:5a:4b
	 jtr NETNTLM:	dom\user:$NETNTLM$3a6fd9227013e34a$a0291f3e348f707fdd43421693eb81b3bb31310cc5385a4b
```
Same observation with asleap successfully cracking the C/R.