### PR TITLE
Detect WPS version 2.x

### DIFF
--- a/src/airodump-ng.c
+++ b/src/airodump-ng.c
@@ -1918,6 +1918,7 @@ skip_probe:
                                 pwfa += pwfa[1] + 2;
                             }
                         }
+                        break;
                     case 0x1054: // Primary Device Type
                         break;
                     case 0x1057: // AP Setup Locked

--- a/src/airodump-ng.c
+++ b/src/airodump-ng.c
@@ -1906,6 +1906,17 @@ skip_probe:
                         break;
                     case 0x1047: // UUID Enrollee
                     case 0x1049: // Vendor Extension
+                        if (memcmp(&p[4], "\x00\x37\x2A", 3) == 0) {
+                            unsigned char *pwfa = &p[7];
+                            short wfa_len = ntohs(*((short *)&p[2]));
+                            while( wfa_len > 0 ) {
+                                if (*pwfa == 0) { // Version2
+                                    ap_cur->wps.version = pwfa[2];
+                                    break;
+                                }
+                                wfa_len -= pwfa[1];
+                            }
+                        }
                     case 0x1054: // Primary Device Type
                         break;
                     case 0x1057: // AP Setup Locked

--- a/src/airodump-ng.c
+++ b/src/airodump-ng.c
@@ -1908,7 +1908,7 @@ skip_probe:
                     case 0x1049: // Vendor Extension
                         if (memcmp(&p[4], "\x00\x37\x2A", 3) == 0) {
                             unsigned char *pwfa = &p[7];
-                            short wfa_len = ntohs(*((short *)&p[2]));
+                            int wfa_len = ntohs(*((short *)&p[2]));
                             while( wfa_len > 0 ) {
                                 if (*pwfa == 0) { // Version2
                                     ap_cur->wps.version = pwfa[2];

--- a/src/airodump-ng.c
+++ b/src/airodump-ng.c
@@ -1914,7 +1914,8 @@ skip_probe:
                                     ap_cur->wps.version = pwfa[2];
                                     break;
                                 }
-                                wfa_len -= pwfa[1];
+                                wfa_len -= pwfa[1] + 2;
+                                pwfa += pwfa[1] + 2;
                             }
                         }
                     case 0x1054: // Primary Device Type


### PR DESCRIPTION
### Brief description:
Currently airodump-ng looks only inside the tag 'version' (0x104a) which is always set to '1.0' (0x10) for backwards compatibility.

### Quotes from the specification:

**Version**: Deprecated. Always set to 0x10 for backwards compatibility. See Version2 for current version negotiation mechanism.
**Version2** (inside **WFA Vendor Extension**): 0x20 = version 2.0, 0x21 = version 2.1, etc. Must be included in protocol version 2.0 and higher.

**WFA Vendor Extension** attribute is a Vendor Extension attribute (ID 0x1049) that uses Vendor ID **0x00372A** and contains one or more subelements. Each subelement starts with a header consisting of one-octet ID field (the sublement ID value from the following table) and one-octet length field (number of octets in the payload of this subelement).

### WFA Vendor Extension format:
Boolean attributes (identified with ‘Bool’ as the Length in the following table) have the Length of one byte (1B) and have two valid values: 0 = FALSE, 1 = TRUE.

| Description             | ID           | Length
|---------------------|----------|---------|
| Version2 | 0x00 | 1B |
| AuthorizedMACs | 0x01 | <=30B |
| Network Key Shareable | 0x02 | Bool |
| Request to Enroll | 0x03 | Bool |
| Settings Delay Time | 0x04 | 1B |
| Reserved for future use | 0x05 to 0xFF | |

