### PR TITLE
Besside-ng: Added automatic channel detection of 2GHz and 5GHz channels

### DIFF
--- a/src/besside-ng.c
+++ b/src/besside-ng.c
@@ -136,6 +136,7 @@ struct channel {
 struct conf {
 	char		*cf_ifname;
 	struct channel	cf_channels;
+	int		cf_autochan;
 	int		cf_hopfreq;
 	int		cf_deauthfreq;
 	unsigned char	*cf_bssid;
@@ -246,6 +247,7 @@ struct state {
 
 static void attack_continue(struct network *n);
 static void attack(struct network *n);
+static void autodetect_channels();
 
 void show_wep_stats(int UNUSED(B), int UNUSED(force),
 		    PTW_tableentry UNUSED(table[PTW_KEYHSBYTES][PTW_n]),
@@ -1610,7 +1612,7 @@ static void attack(struct network *n)
 	channel_set(n->n_chan);
 
 	time_printf(V_VERBOSE,
-		    "Pwning [%s] %s\n", n->n_ssid, mac2str(n->n_bssid));
+		    "Pwning [%s] %s on chan %d\n", n->n_ssid, mac2str(n->n_bssid), n->n_chan);
 
 	if (n->n_start.tv_sec == 0)
 		memcpy(&n->n_start, &_state.s_now, sizeof(n->n_start));
@@ -1839,6 +1841,10 @@ static void wifi_beacon(struct network *n, struct ieee80211_frame *wh,
 		case IEEE80211_ELEMID_RSN:
 			if (parse_rsn(n, p, l, 1) == -1)
 				goto __bad;
+			break;
+
+		case IEEE80211_ELEMID_HTINFO:
+			n->n_chan = *p;
 			break;
 
 		default:
@@ -2950,6 +2956,9 @@ static void pwn(void)
 	time_printf(V_VERBOSE, "mac %s\n", mac2str(_state.s_mac));
 	time_printf(V_NORMAL, "Let's ride\n");
 
+	if (_conf.cf_autochan)
+		autodetect_channels();
+
 	if (wi_set_channel(s->s_wi, _state.s_chan) == -1)
 		err(1, "wi_set_channel()");
 
@@ -3010,14 +3019,45 @@ static void channel_add(int num)
 	c->c_next = _conf.cf_channels.c_next;
 }
 
+static void autodetect_freq(int start, int end, int incr)
+{
+	int freq;
+	int chan;
+
+	for (freq = start; freq <= end; freq += incr)
+	{
+		if (wi_set_freq(_state.s_wi, freq) == 0)
+		{
+			chan = wi_get_channel(_state.s_wi);
+			channel_add(chan);
+			time_printf(V_VERBOSE, "Found channel %d on frequency %d\n", chan, freq);
+		}
+		else
+		{
+			time_printf(V_VERBOSE, "No channel found on frequency %d\n", freq);
+		}
+	}
+}
+
+static void autodetect_channels()
+{
+	time_printf(V_NORMAL, "Autodetecting supported channels...\n");
+
+	// autodetect 2ghz channels
+	autodetect_freq(2412, 2472, 5);	// 1-13
+	autodetect_freq(2484, 2484, 1); // 14
+
+	// autodetect 5ghz channels
+	autodetect_freq(5180, 5320, 10); // 36-64
+	autodetect_freq(5500, 5720, 10); // 100-144
+	autodetect_freq(5745, 5805, 10); // 149-161
+	autodetect_freq(5825, 5825, 1);  // 165
+}
+
 static void init_conf(void)
 {
-	int i;
-
 	_conf.cf_channels.c_next = &_conf.cf_channels;
-
-	for (i = 1; i <= 11; i++)
-		channel_add(i);
+	_conf.cf_autochan = 1;
 
 	_state.s_hopchan = _conf.cf_channels.c_next;
 
@@ -3191,6 +3231,7 @@ int main(int argc, char *argv[])
 			_conf.cf_channels.c_next = &_conf.cf_channels;
 			channel_add(atoi(optarg));
 			_state.s_hopchan = _conf.cf_channels.c_next;
+			_conf.cf_autochan = 0;
 			break;
 
 		case 'v':


### PR DESCRIPTION
The channels in besside-ng were hardcoded from 1 to 11 unless using the -c option to lock to a specific channel.

I've made the necessary changes to detect the channels that the wifi adapter supports automatically, including 5GHz channels. The scanning process will thus be able to scan channels 1-14, 36-64, 100-144, 149-161 and 165 if they are supported.

This also fixes issue #106.

Tested on Alfa AWUS036NHA and Alfa AWUS036AC wifi adapters.