### PR TITLE
[aircrack-ng.c] fix off by one

### DIFF
--- a/src/aircrack-ng.c
+++ b/src/aircrack-ng.c
@@ -815,7 +815,7 @@ int atomic_read( read_buf *rb, int fd, int len, void *buf )
 	}
 	else
 	{
-		n = read( fd, rb->buf1 + rb->off2, 65536 - rb->off2 );
+		n = read( fd, rb->buf1 + rb->off2, 65535 - rb->off2 );
 
 		if( n <= 0 )
 			return( 0 );


### PR DESCRIPTION
I think you are going one past the end of the buffer somewhere, but I'm not quite familiar enough with the code to spot it.

This prevents the segfault, but seems to introduce another bug because not all packets get read.


The offending lines are:
```
825                 if( rb->off2 - rb->off1 >= len )
826                 {
827                         memcpy( buf, rb->buf1 + rb->off1, len ); // <-- Segfault here
828                         rb->off1 += len;
829                         return( 1 );
830                 }
```


```
(gdb) where
#0  __memmove_avx_unaligned_erms () at ../sysdeps/x86_64/multiarch/memmove-vec-unaligned-erms.S:416
#1  0x000055555555e877 in memcpy (__len=280, __src=<optimized out>, __dest=0x7ffff00008c0) at /usr/include/x86_64-linux-gnu/bits/string3.h:53
#2  atomic_read (rb=0x555555793b90 <crb>, fd=9, len=280, buf=0x7ffff00008c0) at aircrack-ng.c:827
#3  0x000055555555ec27 in check_thread (arg=<optimized out>) at aircrack-ng.c:1970
#4  0x00007ffff7bc06da in start_thread (arg=0x7fffef7fe700) at pthread_create.c:456
#5  0x00007ffff6f1717f in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:105
(gdb) info locals
n = <optimized out>
buf = 0x7ffff00008c0
len = 280
fd = 9
rb = 0x555555793b90 <crb>
(gdb) display *buf
6: *buf = <error: Attempt to dereference a generic pointer.>
(gdb) display *rb
7: *rb = {off1 = 16692, off2 = 65536, buf1 = 0x7fffe81b6450, buf2 = 0x7fffe81c6460}
```


Packaged behavior:
```
$ dpkg -l | grep aircrack
ii  aircrack-ng                         1:1.2-0~rc4-2                        amd64        wireless WEP/WPA cracking utilities
```
```
$ aircrack-ng /srv/wifi/*.pcapdump
Opening /srv/wifi/Kismet-20170512-14-14-55-1.pcapdump
Opening /srv/wifi/Kismet-20170512-15-21-53-1.pcapdump
Opening /srv/wifi/Kismet-20170512-15-42-15-1.pcapdump

Invalid packet capture length 0 - corrupted file?
Unsupported file format (not a pcap or IVs file).
Opening /srv/wifi/Kismet-20170512-19-06-01-1.pcapdump
Opening /srv/wifi/Kismet-20170512-19-41-11-1.pcapdump

Invalid packet capture length 0 - corrupted file?
Unsupported file format (not a pcap or IVs file).
Opening /srv/wifi/Kismet-20170514-11-30-26-1.pcapdump
Opening /srv/wifi/Kismet-20170514-12-15-05-1.pcapdump
Opening /srv/wifi/Kismet-20170514-12-23-36-1.pcapdump

Invalid packet capture length 0 - corrupted file?
Segmentation fault
```

Testing that each file is valid:
```
for file in /srv/wifi/*.pcapdump; do echo $file; aircrack-ng -e test-ssid $file; echo $?; done
# bunch of output, everything works when done one at a time
```

The behavior with this fix applied:
```
$ ./aircrack-ng /srv/wifi/*.pcapdump
Opening /srv/wifi/Kismet-20170512-14-14-55-1.pcapdump
Opening /srv/wifi/Kismet-20170512-15-21-53-1.pcapdump
Opening /srv/wifi/Kismet-20170512-15-42-15-1.pcapdump
Opening /srv/wifi/Kismet-20170512-19-06-01-1.pcapdump
Opening /srv/wifi/Kismet-20170512-19-41-11-1.pcapdump
Opening /srv/wifi/Kismet-20170514-11-30-26-1.pcapdump
Opening /srv/wifi/Kismet-20170514-12-15-05-1.pcapdump
Opening /srv/wifi/Kismet-20170514-12-23-36-1.pcapdump
Opening /srv/wifi/Kismet-20170514-17-37-34-1.pcapdump
Opening /srv/wifi/Kismet-20170515-00-07-52-1.pcapdump
Opening /srv/wifi/Kismet-20170515-01-42-40-1.pcapdump
Opening /srv/wifi/Kismet-20170515-12-19-15-1.pcapdump
Opening /srv/wifi/Kismet-20170517-15-22-55-1.pcapdump
Read 360812 packets.
```

It is interesting because....
```
$ for file in /srv/wifi/*.pcapdump; do echo $file; aircrack-ng -e test-ssid $file; echo $?; done | grep "packets"
Read 231455 packets.
Read 614339 packets.
Read 539371 packets.
Read 7042979 packets.
Read 3597963 packets.
Read 1256 packets.
Read 652876 packets.
Read 972675 packets.
Read 10849675 packets.
Read 225100 packets.
Read 1546893 packets.
Read 7290154 packets.
Read 1020664 packets.
```
Seems more than `360812` packets
