### PR TITLE
skipping broken frames

### DIFF
--- a/src/besside-ng.c
+++ b/src/besside-ng.c
@@ -2550,9 +2550,15 @@ static void wifi_read(void)
     struct ieee80211_frame* wh = (struct ieee80211_frame*) buf;
 	struct network *n;
 
+	memset(buf, 0, sizeof(buf));
+
 	rd = wi_read(s->s_wi, buf, sizeof(buf), &ri);
 	if (rd < 0)
 		err(1, "wi_read()");
+
+	if (rd < sizeof(struct ieee80211_frame)) {
+		return;
+	}
 
 	s->s_ri = &ri;
 


### PR DESCRIPTION
On KALI some adapters (internal BCM4339 / external TP-LINK TL-WN722N) `wi_read()` sometimes return 0 or less than `struct ieee80211_frame` size that leads to unpredictable results caused by uninitialized `buff`

this patch may be relevant to:
#https://github.com/aircrack-ng/aircrack-ng/pull/66
#https://github.com/aircrack-ng/aircrack-ng/issues/48