### PR TITLE
Add and fix prototypes in the codebase

### DIFF
--- a/src/aircrack-ng.c
+++ b/src/aircrack-ng.c
@@ -251,7 +251,7 @@ int intr_read = 0;
 
 int safe_write( int fd, void *buf, size_t len );
 
-void clean_exit(int ret)
+static void clean_exit(int ret)
 {
 	struct AP_info *ap_cur;
 	struct AP_info *ap_next;
@@ -430,7 +430,7 @@ void clean_exit(int ret)
 	_exit(ret);
 }
 
-void sighandler( int signum )
+static void sighandler( int signum )
 {
 	#if ((defined(__INTEL_COMPILER) || defined(__ICC)) && defined(DO_PGO_DUMP))
 	_PGOPTI_Prof_Dump();
@@ -467,7 +467,7 @@ void sighandler( int signum )
 		printf( "\33[2J\n" );
 }
 
-void eof_wait( int *eof_notified )
+static void eof_wait( int *eof_notified )
 {
 	if( *eof_notified == 0 )
 	{
@@ -484,9 +484,7 @@ void eof_wait( int *eof_notified )
 	usleep( 100000 );
 }
 
-int wpa_send_passphrase(char *key, struct WPA_data* data, int lock);
-
-inline int wpa_send_passphrase(char *key, struct WPA_data* data, int lock)
+static inline int wpa_send_passphrase(char *key, struct WPA_data* data, int lock)
 {
 	int delta = 0, i = 0, fincnt = 0;
 	off_t tmpword = 0;
@@ -547,9 +545,7 @@ inline int wpa_send_passphrase(char *key, struct WPA_data* data, int lock)
 	return 1;
 }
 
-int wpa_receive_passphrase(char *key, struct WPA_data* data);
-
-inline int wpa_receive_passphrase(char *key, struct WPA_data* data)
+static inline int wpa_receive_passphrase(char *key, struct WPA_data* data)
 {
 	pthread_mutex_lock(&data->mutex);
 
@@ -574,7 +570,7 @@ inline int wpa_receive_passphrase(char *key, struct WPA_data* data)
 
     Return value is negative for failures
 */
-int checkbssids(char *bssidlist)
+static int checkbssids(char *bssidlist)
 {
 	int first = 1;
 	int failed = 0;
@@ -659,7 +655,7 @@ int checkbssids(char *bssidlist)
 	return nbBSSID;
 }
 
-int mergebssids(char * bssidlist, unsigned char * bssid)
+static int mergebssids(char * bssidlist, unsigned char * bssid)
 {
 	struct mergeBSSID * list_prev;
 	struct mergeBSSID * list_cur;
@@ -778,7 +774,7 @@ int mergebssids(char * bssidlist, unsigned char * bssid)
 
 /* fread isn't atomic, sadly */
 
-int atomic_read( read_buf *rb, int fd, int len, void *buf )
+static int atomic_read( read_buf *rb, int fd, int len, void *buf )
 {
 	int n;
 
@@ -833,7 +829,7 @@ int atomic_read( read_buf *rb, int fd, int len, void *buf )
 	return( 0 );
 }
 
-void read_thread( void *arg )
+static void read_thread( void *arg )
 {
 	int fd, n, fmt;
 	unsigned z;
@@ -1788,7 +1784,7 @@ void read_thread( void *arg )
 	_exit( FAILURE );
 }
 
-void check_thread( void *arg )
+static void check_thread( void *arg )
 {
 	int fd, n, fmt;
 	unsigned z;
@@ -2600,7 +2596,7 @@ float chrono( struct timeval *start, int reset )
 
 /* signal-safe I/O routines */
 
-int safe_read( int fd, void *buf, size_t len )
+static int safe_read( int fd, void *buf, size_t len )
 {
 	int n;
 	size_t sum = 0;
@@ -2645,7 +2641,7 @@ int safe_write( int fd, void *buf, size_t len )
 
 /* each thread computes the votes over a subset of the IVs */
 
-int crack_wep_thread( void *arg )
+static int crack_wep_thread( void *arg )
 {
 	long xv, min, max;
 	unsigned char jj[256];
@@ -3136,7 +3132,7 @@ static void key_found(unsigned char *wepkey, int keylen, int B)
 
 /* test if the current WEP key is valid */
 
-int check_wep_key( unsigned char *wepkey, int B, int keylen )
+static int check_wep_key( unsigned char *wepkey, int B, int keylen )
 {
 	unsigned char x1, x2;
 	unsigned long xv;
@@ -3211,7 +3207,7 @@ int check_wep_key( unsigned char *wepkey, int B, int keylen )
 
 /* routine used to sort the votes */
 
-int cmp_votes( const void *bs1, const void *bs2 )
+static int cmp_votes( const void *bs1, const void *bs2 )
 {
 	if( ((vote *) bs1)->val < ((vote *) bs2)->val )
 		return(  1 );
@@ -3224,7 +3220,7 @@ int cmp_votes( const void *bs1, const void *bs2 )
 
 /* sum up the votes and sort them */
 
-int calc_poll( int B )
+static int calc_poll( int B )
 {
 	int i, n, cid, *vi;
 	int votes[N_ATTACKS][256];
@@ -3313,7 +3309,7 @@ int calc_poll( int B )
 	return( SUCCESS );
 }
 
-int update_ivbuf( void )
+static int update_ivbuf( void )
 {
 	int n;
 	struct AP_info *ap_cur;
@@ -3390,7 +3386,7 @@ int update_ivbuf( void )
  * It will remove votes for a specific keybyte (and remove from the requested current value)
  * Return 0 on success, another value on failure
  */
-int remove_votes(int keybyte, unsigned char value)
+static int remove_votes(int keybyte, unsigned char value)
 {
 	int i;
 	int found = 0;
@@ -3430,7 +3426,7 @@ int remove_votes(int keybyte, unsigned char value)
  * reaches B == keylen. It also stops when the current keybyte vote *
  * is lower than the highest vote divided by the fudge factor.      */
 
-int do_wep_crack1( int B )
+static int do_wep_crack1( int B )
 {
 	int i, j, l, m, tsel, charread;
 	int remove_keybyte_nr, remove_keybyte_value;
@@ -3723,7 +3719,7 @@ int do_wep_crack1( int B )
 
 /* experimental single bruteforce attack */
 
-int do_wep_crack2( int B )
+static int do_wep_crack2( int B )
 {
 	int i, j;
 
@@ -3808,7 +3804,7 @@ int do_wep_crack2( int B )
 	return( FAILURE );
 }
 
-int inner_bruteforcer_thread(void *arg)
+static int inner_bruteforcer_thread(void *arg)
 {
 	int i, j, k, l, reduce=0;
 	size_t nthread = (size_t)arg;
@@ -3919,7 +3915,7 @@ int inner_bruteforcer_thread(void *arg)
 
 /* display the current wpa key info, matrix-like */
 
-void show_wpa_stats( char *key, int keylen, unsigned char pmk[32], unsigned char ptk[64],
+static void show_wpa_stats( char *key, int keylen, unsigned char pmk[32], unsigned char ptk[64],
 unsigned char mic[16], int force )
 {
 	float delta, calc, ksec;
@@ -4030,7 +4026,7 @@ __out:
 }
 
 
-int crack_wpa_thread( void *arg )
+static int crack_wpa_thread( void *arg )
 {
 	FILE * keyFile;
 	char  essid[36];
@@ -4263,7 +4259,7 @@ int crack_wpa_thread( void *arg )
  * nb: index of the dictionary
  * return 0 on success and FAILURE if it failed
  */
-int next_dict(int nb)
+static int next_dict(int nb)
 {
 	off_t tmpword = 0;
 
@@ -4400,7 +4396,7 @@ int sql_wpacallback(void* arg, int ccount, char** values, char** columnnames ) {
 }
 #endif
 
-int do_make_wkp(struct AP_info *ap_cur)
+static int do_make_wkp(struct AP_info *ap_cur)
 {
 	size_t elt_written;
 	unsigned i = 0;
@@ -4551,7 +4547,7 @@ int do_make_wkp(struct AP_info *ap_cur)
 	return( 1 );
 }
 
-int do_make_hccap(struct AP_info *ap_cur)
+static int do_make_hccap(struct AP_info *ap_cur)
 {
 	size_t elt_written;
 	unsigned i = 0;
@@ -4683,7 +4679,7 @@ int do_make_hccap(struct AP_info *ap_cur)
 	return( 1 );
 }
 
-int do_wpa_crack()
+static int do_wpa_crack(void)
 {
 	int i, j, cid, num_cpus, res;
 	char key1[128];
@@ -4784,7 +4780,7 @@ int do_wpa_crack()
 	return( FAILURE );
 }
 
-int next_key( char **key, int keysize )
+static int next_key( char **key, int keysize )
 {
 	char *tmp, *tmpref;
 	int i, rtn;
@@ -4903,7 +4899,7 @@ int next_key( char **key, int keysize )
 	return( SUCCESS );
 }
 
-int set_dicts(char* optargs)
+static int set_dicts(char* optargs)
 {
 	int len;
 	char *optarg;
@@ -4945,7 +4941,7 @@ Uses the specified dictionary to crack the WEP key.
 Return: SUCCESS if it cracked the key,
         FAILURE if it could not.
 */
-int crack_wep_dict()
+static int crack_wep_dict(void)
 {
 	struct timeval t_last;
 	struct timeval t_now;

--- a/src/aircrack-ng.h
+++ b/src/aircrack-ng.h
@@ -109,10 +109,10 @@ extern int getmac(char * macAddress, int strict, unsigned char * mac);
 extern int readLine(char line[], int maxlength);
 extern int hexToInt(char s[], int len);
 extern int hexCharToInt(unsigned char c);
-extern int cpuid_simdsize();
-extern int cpuid_getinfo();
+extern int cpuid_simdsize(int viewmax);
+extern int cpuid_getinfo(void);
 extern struct _cpuinfo cpuinfo;
-extern int get_nb_cpus();
+extern int get_nb_cpus(void);
 
 #define S_LLC_SNAP      "\xAA\xAA\x03\x00\x00\x00"
 #define S_LLC_SNAP_ARP  (S_LLC_SNAP "\x08\x06")

--- a/src/aircrack-ptw-lib.h
+++ b/src/aircrack-ptw-lib.h
@@ -99,7 +99,7 @@ typedef struct {
 	rc4test_func rc4test;
 } PTW_attackstate;
 
-PTW_attackstate * PTW_newattackstate();
+PTW_attackstate * PTW_newattackstate(void);
 void PTW_freeattackstate(PTW_attackstate *);
 int PTW_addsession(PTW_attackstate *, uint8_t *, uint8_t *, int *, int);
 int PTW_computeKey(PTW_attackstate *, uint8_t *, int, int, int *, int [][PTW_n], int attacks);

--- a/src/airdecap-ng.c
+++ b/src/airdecap-ng.c
@@ -112,7 +112,7 @@ unsigned char buffer2[65536];
 
 /* this routine handles to 802.11 to Ethernet translation */
 
-int write_packet( FILE *f_out, struct pcap_pkthdr *pkh, unsigned char *h80211 )
+static int write_packet( FILE *f_out, struct pcap_pkthdr *pkh, unsigned char *h80211 )
 {
     int n;
     unsigned char arphdr[12];

--- a/src/airdecloak-ng.c
+++ b/src/airdecloak-ng.c
@@ -313,7 +313,7 @@ void print_packet(struct packet_elt * packet) {
 	printf("Signal: %d - Retry bit: %d - is cloaked: %d\n", packet->signal_quality, packet->retry_bit, packet->is_cloaked);
 }
 
-int get_rtap_signal(int caplen)
+static int get_rtap_signal(int caplen)
 {
 	struct ieee80211_radiotap_iterator iterator;
 	struct ieee80211_radiotap_header *rthdr;

--- a/src/airdecloak-ng.h
+++ b/src/airdecloak-ng.h
@@ -156,53 +156,53 @@ extern int getmac(char * macAddress, int strict, unsigned char * mac);
 extern char * mac2string(unsigned char * mac);
 extern int maccmp(unsigned char *mac1, unsigned char *mac2);
 
-void usage();
+void usage(void);
 int getBits(unsigned char b, int from, int length);
 FILE * openfile(const char * filename, const char * mode, int fatal);
 BOOLEAN write_packet(FILE * file, struct packet_elt * packet);
 FILE * init_new_pcap(const char * filename);
 FILE * open_existing_pcap(const char * filename);
 BOOLEAN read_packets(void);
-BOOLEAN initialize_linked_list();
-BOOLEAN add_node_if_not_complete();
-void set_node_complete();
-void remove_last_uncomplete_node();
+BOOLEAN initialize_linked_list(void);
+BOOLEAN add_node_if_not_complete(void);
+void set_node_complete(void);
+void remove_last_uncomplete_node(void);
 struct packet_elt * getPacketNr(int position);
 char * iv2string(unsigned char * iv);
 char * icv2string(unsigned char * icv);
 void print_packet(struct packet_elt * packet);
-void reset_current_packet_pointer();
-BOOLEAN reset_current_packet_pointer_to_ap_packet();
-BOOLEAN reset_current_packet_pointer_to_client_packet();
-BOOLEAN next_packet_pointer();
-BOOLEAN next_packet_pointer_from_ap();
-BOOLEAN next_packet_pointer_from_client();
-BOOLEAN prev_packet_pointer();
+void reset_current_packet_pointer(void);
+BOOLEAN reset_current_packet_pointer_to_ap_packet(void);
+BOOLEAN reset_current_packet_pointer_to_client_packet(void);
+BOOLEAN next_packet_pointer(void);
+BOOLEAN next_packet_pointer_from_ap(void);
+BOOLEAN next_packet_pointer_from_client(void);
+BOOLEAN prev_packet_pointer(void);
 int compare_SN_to_current_packet(struct packet_elt * packet);
 BOOLEAN current_packet_pointer_same_fromToDS_and_source(struct packet_elt * packet);
 BOOLEAN prev_packet_pointer_same_fromToDS_and_source(struct packet_elt * packet);
 BOOLEAN next_packet_pointer_same_fromToDS_and_source(struct packet_elt * packet);
-BOOLEAN prev_packet_pointer_same_fromToDS_and_source_as_current();
-BOOLEAN next_packet_pointer_same_fromToDS_and_source_as_current();
-BOOLEAN write_packets();
-BOOLEAN print_statistics();
+BOOLEAN prev_packet_pointer_same_fromToDS_and_source_as_current(void);
+BOOLEAN next_packet_pointer_same_fromToDS_and_source_as_current(void);
+BOOLEAN write_packets(void);
+BOOLEAN print_statistics(void);
 char * status_format(int status);
-int get_average_signal_ap();
+int get_average_signal_ap(void);
 
 // Check for cloaking functions
-BOOLEAN check_for_cloaking(); // Main cloaking check function
+BOOLEAN check_for_cloaking(void); // Main cloaking check function
 #define CFC_base_filter() CFC_with_valid_packets_mark_others_with_identical_sn_cloaked()
-int CFC_with_valid_packets_mark_others_with_identical_sn_cloaked();
+int CFC_with_valid_packets_mark_others_with_identical_sn_cloaked(void);
 int CFC_mark_all_frames_with_status_to(int original_status, int new_status);
-int CFC_filter_signal();
-int CFC_filter_duplicate_sn_ap();
-int CFC_filter_duplicate_sn_client();
-int CFC_filter_duplicate_sn();
-int CFC_filter_consecutive_sn();
-int CFC_filter_consecutive_sn_ap();
-int CFC_filter_consecutive_sn_client();
-int CFC_filter_duplicate_iv();
-int CFC_filter_signal_duplicate_and_consecutive_sn();
+int CFC_filter_signal(void);
+int CFC_filter_duplicate_sn_ap(void);
+int CFC_filter_duplicate_sn_client(void);
+int CFC_filter_duplicate_sn(void);
+int CFC_filter_consecutive_sn(void);
+int CFC_filter_consecutive_sn_ap(void);
+int CFC_filter_consecutive_sn_client(void);
+int CFC_filter_duplicate_iv(void);
+int CFC_filter_signal_duplicate_and_consecutive_sn(void);
 
 /*
 const char usage[] =

--- a/src/aireplay-ng.c
+++ b/src/aireplay-ng.c
@@ -344,7 +344,7 @@ int ctrl_c, alarmed;
 char * iwpriv;
 
 
-void sighandler( int signum )
+static void sighandler( int signum )
 {
     if( signum == SIGINT )
         ctrl_c++;
@@ -353,7 +353,7 @@ void sighandler( int signum )
         alarmed++;
 }
 
-int reset_ifaces()
+static int reset_ifaces(void)
 {
     //close interfaces
     if(_wi_in != _wi_out)
@@ -409,7 +409,7 @@ int reset_ifaces()
     return 0;
 }
 
-int set_bitrate(struct wif *wi, int rate)
+static int set_bitrate(struct wif *wi, int rate)
 {
     int i, newrate;
 
@@ -496,7 +496,7 @@ int set_bitrate(struct wif *wi, int rate)
     return 0;
 }
 
-int send_packet(void *buf, size_t count)
+static int send_packet(void *buf, size_t count)
 {
 	struct wif *wi = _wi_out; /* XXX globals suck */
 	unsigned char *pkt = (unsigned char*) buf;
@@ -523,7 +523,7 @@ int send_packet(void *buf, size_t count)
 	return 0;
 }
 
-int read_packet(void *buf, size_t count, struct rx_info *ri)
+static int read_packet(void *buf, size_t count, struct rx_info *ri)
 {
 	struct wif *wi = _wi_in; /* XXX */
 	int rc;
@@ -542,7 +542,7 @@ int read_packet(void *buf, size_t count, struct rx_info *ri)
 	return rc;
 }
 
-void read_sleep( unsigned long usec )
+static void read_sleep( unsigned long usec )
 {
     struct timeval tv, tv2, tv3;
     int caplen;
@@ -572,7 +572,7 @@ void read_sleep( unsigned long usec )
 }
 
 
-int filter_packet( unsigned char *h80211, int caplen )
+static int filter_packet( unsigned char *h80211, int caplen )
 {
     int z, mi_b, mi_s, mi_d, ext=0, qos;
 
@@ -642,7 +642,7 @@ int filter_packet( unsigned char *h80211, int caplen )
     return( 0 );
 }
 
-int wait_for_beacon(unsigned char *bssid, unsigned char *capa, char *essid)
+static int wait_for_beacon(unsigned char *bssid, unsigned char *capa, char *essid)
 {
     int len = 0, chan = 0, taglen = 0, tagtype = 0, pos = 0;
     unsigned char pkt_sniff[4096];
@@ -754,7 +754,7 @@ int wait_for_beacon(unsigned char *bssid, unsigned char *capa, char *essid)
 /**
     if bssid != NULL its looking for a beacon frame
 */
-int attack_check(unsigned char* bssid, char* essid, unsigned char* capa, struct wif *wi)
+static int attack_check(unsigned char* bssid, char* essid, unsigned char* capa, struct wif *wi)
 {
     int ap_chan=0, iface_chan=0;
 
@@ -785,7 +785,7 @@ int attack_check(unsigned char* bssid, char* essid, unsigned char* capa, struct 
     return 0;
 }
 
-int getnet( unsigned char* capa, int filter, int force)
+static int getnet( unsigned char* capa, int filter, int force)
 {
     unsigned char *bssid;
 
@@ -846,7 +846,7 @@ int getnet( unsigned char* capa, int filter, int force)
     return 0;
 }
 
-int xor_keystream(unsigned char *ph80211, unsigned char *keystream, int len)
+static int xor_keystream(unsigned char *ph80211, unsigned char *keystream, int len)
 {
     int i=0;
 
@@ -857,7 +857,7 @@ int xor_keystream(unsigned char *ph80211, unsigned char *keystream, int len)
     return 0;
 }
 
-int capture_ask_packet( int *caplen, int just_grab )
+static int capture_ask_packet( int *caplen, int just_grab )
 {
     time_t tr;
     struct timeval tv;
@@ -1191,7 +1191,7 @@ int capture_ask_packet( int *caplen, int just_grab )
     return( 0 );
 }
 
-int read_prga(unsigned char **dest, char *file)
+static int read_prga(unsigned char **dest, char *file)
 {
     FILE *f;
     int size;
@@ -1226,7 +1226,7 @@ int read_prga(unsigned char **dest, char *file)
     return( 0 );
 }
 
-void add_icv(unsigned char *input, int len, int offset)
+static void add_icv(unsigned char *input, int len, int offset)
 {
     unsigned long crc = 0xFFFFFFFF;
     int n=0;
@@ -1244,7 +1244,7 @@ void add_icv(unsigned char *input, int len, int offset)
     return;
 }
 
-void send_fragments(unsigned char *packet, int packet_len, unsigned char *iv, unsigned char *keystream, int fragsize, int ska)
+static void send_fragments(unsigned char *packet, int packet_len, unsigned char *iv, unsigned char *keystream, int fragsize, int ska)
 {
     int t, u;
     int data_size;
@@ -1311,7 +1311,7 @@ void send_fragments(unsigned char *packet, int packet_len, unsigned char *iv, un
 
 }
 
-int do_attack_deauth( void )
+static int do_attack_deauth( void )
 {
     int i, n;
     int aacks, sacks, caplen;
@@ -1443,7 +1443,7 @@ int do_attack_deauth( void )
     return( 0 );
 }
 
-int do_attack_fake_auth( void )
+static int do_attack_fake_auth( void )
 {
     time_t tt, tr;
     struct timeval tv, tv2, tv3;
@@ -2233,7 +2233,7 @@ int do_attack_fake_auth( void )
     return( 0 );
 }
 
-int do_attack_interactive( void )
+static int do_attack_interactive( void )
 {
     int caplen, n, z;
     int mi_b, mi_s, mi_d;
@@ -2375,7 +2375,7 @@ read_packets:
     return( 0 );
 }
 
-int do_attack_arp_resend( void )
+static int do_attack_arp_resend( void )
 {
     int nb_bad_pkt;
     int arp_off1, arp_off2;
@@ -2812,7 +2812,7 @@ add_arp:
     return( 0 );
 }
 
-int do_attack_caffe_latte( void )
+static int do_attack_caffe_latte( void )
 {
     int nb_bad_pkt;
     int arp_off1, arp_off2;
@@ -3260,7 +3260,7 @@ add_arp:
     return( 0 );
 }
 
-int do_attack_migmode( void )
+static int do_attack_migmode( void )
 {
     int nb_bad_pkt;
     int arp_off1, arp_off2;
@@ -3711,7 +3711,7 @@ add_arp:
     return( 0 );
 }
 
-int set_clear_arp(unsigned char *buf, unsigned char *smac, unsigned char *dmac) //set first 22 bytes
+static int set_clear_arp(unsigned char *buf, unsigned char *smac, unsigned char *dmac) //set first 22 bytes
 {
     if(buf == NULL)
         return -1;
@@ -3733,7 +3733,7 @@ int set_clear_arp(unsigned char *buf, unsigned char *smac, unsigned char *dmac) 
     return 0;
 }
 
-int set_final_arp(unsigned char *buf, unsigned char *mymac)
+static int set_final_arp(unsigned char *buf, unsigned char *mymac)
 {
     if(buf == NULL)
         return -1;
@@ -3755,7 +3755,7 @@ int set_final_arp(unsigned char *buf, unsigned char *mymac)
     return 0;
 }
 
-int set_clear_ip(unsigned char *buf, int ip_len) //set first 9 bytes
+static int set_clear_ip(unsigned char *buf, int ip_len) //set first 9 bytes
 {
     if(buf == NULL)
         return -1;
@@ -3768,7 +3768,7 @@ int set_clear_ip(unsigned char *buf, int ip_len) //set first 9 bytes
     return 0;
 }
 
-int set_final_ip(unsigned char *buf, unsigned char *mymac)
+static int set_final_ip(unsigned char *buf, unsigned char *mymac)
 {
     if(buf == NULL)
         return -1;
@@ -3786,7 +3786,7 @@ int set_final_ip(unsigned char *buf, unsigned char *mymac)
     return 0;
 }
 
-int do_attack_cfrag( void )
+static int do_attack_cfrag( void )
 {
     int caplen, n;
     struct timeval tv;
@@ -4092,7 +4092,7 @@ read_packets:
     return( 0 );
 }
 
-int do_attack_chopchop( void )
+static int do_attack_chopchop( void )
 {
     float f, ticks[4];
     int i, j, n, z, caplen, srcz;
@@ -4764,7 +4764,7 @@ int do_attack_chopchop( void )
     return( 0 );
 }
 
-int make_arp_request(unsigned char *h80211, unsigned char *bssid, unsigned char *src_mac, unsigned char *dst_mac, unsigned char *src_ip, unsigned char *dst_ip, int size)
+static int make_arp_request(unsigned char *h80211, unsigned char *bssid, unsigned char *src_mac, unsigned char *dst_mac, unsigned char *src_ip, unsigned char *dst_ip, int size)
 {
 	unsigned char *arp_header = (unsigned char*)"\xaa\xaa\x03\x00\x00\x00\x08\x06\x00\x01\x08\x00\x06\x04\x00\x01";
 	unsigned char *header80211 = (unsigned char*)"\x08\x41\x95\x00";
@@ -4790,7 +4790,7 @@ int make_arp_request(unsigned char *h80211, unsigned char *bssid, unsigned char 
     return 0;
 }
 
-void save_prga(char *filename, unsigned char *iv, unsigned char *prga, int prgalen)
+static void save_prga(char *filename, unsigned char *iv, unsigned char *prga, int prgalen)
 {
     FILE *xorfile;
     size_t unused;
@@ -4800,7 +4800,7 @@ void save_prga(char *filename, unsigned char *iv, unsigned char *prga, int prgal
     fclose (xorfile);
 }
 
-int do_attack_fragment()
+static int do_attack_fragment(void)
 {
     unsigned char packet[4096];
     unsigned char packet2[4096];
@@ -5317,7 +5317,7 @@ int do_attack_fragment()
     return( 0 );
 }
 
-int grab_essid(unsigned char* packet, int len)
+static int grab_essid(unsigned char* packet, int len)
 {
     int i=0, j=0, pos=0, tagtype=0, taglen=0, chan=0;
     unsigned char bssid[6];
@@ -5424,7 +5424,7 @@ out:
 	return port;
 }
 
-void dump_packet(unsigned char* packet, int len)
+static void dump_packet(unsigned char* packet, int len)
 {
     int i=0;
 
@@ -5443,7 +5443,7 @@ struct net_hdr {
 	uint8_t		nh_data[0];
 } __packed;
 
-int tcp_test(const char* ip_str, const short port)
+static int tcp_test(const char* ip_str, const short port)
 {
     int sock, i;
     struct sockaddr_in s_in;
@@ -5660,7 +5660,7 @@ int tcp_test(const char* ip_str, const short port)
     return 0;
 }
 
-int do_attack_test()
+static int do_attack_test(void)
 {
     unsigned char packet[4096];
     struct timeval tv, tv2, tv3;

--- a/src/airodump-ng.c
+++ b/src/airodump-ng.c
@@ -87,7 +87,9 @@ extern int is_string_number(const char * str);
 void dump_sort( void );
 void dump_print( int ws_row, int ws_col, int if_num );
 
-char * get_manufacturer_from_string(char * buffer) {
+static char *get_manufacturer(unsigned char mac0, unsigned char mac1, unsigned char mac2);
+
+static char * get_manufacturer_from_string(char * buffer) {
 	char * manuf = NULL;
 	char * buffer_manuf;
 	if (buffer != NULL && strlen(buffer) > 0) {
@@ -122,7 +124,7 @@ char * get_manufacturer_from_string(char * buffer) {
 	return manuf;
 }
 
-void textcolor(int attr, int fg, int bg)
+static void textcolor(int attr, int fg, int bg)
 {	char command[13];
 
 	/* Command is the control command to the terminal */
@@ -131,7 +133,7 @@ void textcolor(int attr, int fg, int bg)
 	fflush(stderr);
 }
 
-void textcolor_fg(int fg)
+static void textcolor_fg(int fg)
 {	char command[13];
 
 	/* Command is the control command to the terminal */
@@ -140,7 +142,7 @@ void textcolor_fg(int fg)
 	fflush(stderr);
 }
 
-void textcolor_bg(int bg)
+static void textcolor_bg(int bg)
 {	char command[13];
 
 	/* Command is the control command to the terminal */
@@ -149,7 +151,7 @@ void textcolor_bg(int bg)
 	fflush(stderr);
 }
 
-void textstyle(int attr)
+static void textstyle(int attr)
 {	char command[13];
 
 	/* Command is the control command to the terminal */
@@ -158,7 +160,7 @@ void textstyle(int attr)
 	fflush(stderr);
 }
 
-void reset_term() {
+static void reset_term(void) {
   struct termios oldt,
                  newt;
   tcgetattr( STDIN_FILENO, &oldt );
@@ -167,7 +169,7 @@ void reset_term() {
   tcsetattr( STDIN_FILENO, TCSANOW, &newt );
 }
 
-int mygetch( ) {
+static int mygetch(void) {
   struct termios oldt,
                  newt;
   int            ch;
@@ -180,7 +182,7 @@ int mygetch( ) {
   return ch;
 }
 
-void resetSelection()
+static void resetSelection(void)
 {
     G.sort_by = SORT_BY_POWER;
     G.sort_inv = 1;
@@ -213,7 +215,7 @@ void resetSelection()
 #define KEY_r		0x72	//realtime sort (de)activate
 #define KEY_s		0x73	//cycle through sorting
 
-void input_thread( void *arg) {
+static void input_thread( void *arg) {
 
     if(!arg){}
 
@@ -389,7 +391,7 @@ void input_thread( void *arg) {
     }
 }
 
-void trim(char *str)
+static void trim(char *str)
 {
     int i;
     int begin = 0;
@@ -403,7 +405,7 @@ void trim(char *str)
     str[i - begin] = '\0'; // Null terminate string.
 }
 
-FILE *open_oui_file(void) {
+static FILE *open_oui_file(void) {
 	int i;
 	FILE *fp = NULL;
 
@@ -417,7 +419,7 @@ FILE *open_oui_file(void) {
 	return fp;
 }
 
-struct oui * load_oui_file(void) {
+static struct oui * load_oui_file(void) {
 	FILE *fp;
 	char * manuf;
 	char buffer[BUFSIZ];
@@ -483,7 +485,7 @@ struct oui * load_oui_file(void) {
 	return oui_head;
 }
 
-int check_shared_key(unsigned char *h80211, int caplen)
+static int check_shared_key(unsigned char *h80211, int caplen)
 {
     int m_bmac, m_smac, m_dmac, n, textlen;
     char ofn[1024];
@@ -635,7 +637,7 @@ int check_shared_key(unsigned char *h80211, int caplen)
     return 0;
 }
 
-char usage[] =
+static char usage[] =
 
 "\n"
 "  %s - (C) 2006-2015 Thomas d\'Otreppe\n"
@@ -694,7 +696,7 @@ char usage[] =
 "      --help                : Displays this usage screen\n"
 "\n";
 
-int is_filtered_netmask(unsigned char *bssid)
+static int is_filtered_netmask(unsigned char *bssid)
 {
     unsigned char mac1[6];
     unsigned char mac2[6];
@@ -714,7 +716,7 @@ int is_filtered_netmask(unsigned char *bssid)
     return 0;
 }
 
-int is_filtered_essid(unsigned char *essid)
+static int is_filtered_essid(unsigned char *essid)
 {
     int ret = 0;
     int i;
@@ -742,7 +744,7 @@ int is_filtered_essid(unsigned char *essid)
     return ret;
 }
 
-void update_rx_quality( )
+static void update_rx_quality(void)
 {
     unsigned int time_diff, capt_time, miss_time;
     int missed_frames;
@@ -822,7 +824,7 @@ void update_rx_quality( )
 
 /* setup the output files */
 
-int dump_initialize( char *prefix, int ivs_only )
+static int dump_initialize( char *prefix, int ivs_only )
 {
     int i, ofn_len;
     FILE *f;
@@ -1004,7 +1006,7 @@ int dump_initialize( char *prefix, int ivs_only )
     return( 0 );
 }
 
-int update_dataps()
+static int update_dataps(void)
 {
     struct timeval tv;
     struct AP_info *ap_cur;
@@ -1060,7 +1062,7 @@ int update_dataps()
     return(0);
 }
 
-int list_tail_free(struct pkt_buf **list)
+static int list_tail_free(struct pkt_buf **list)
 {
     struct pkt_buf **pkts;
     struct pkt_buf *next;
@@ -1091,7 +1093,7 @@ int list_tail_free(struct pkt_buf **list)
     return 0;
 }
 
-int list_add_packet(struct pkt_buf **list, int length, unsigned char* packet)
+static int list_add_packet(struct pkt_buf **list, int length, unsigned char* packet)
 {
     struct pkt_buf *next = *list;
 
@@ -1118,7 +1120,7 @@ int list_add_packet(struct pkt_buf **list, int length, unsigned char* packet)
  * The reason is that the first two bytes unencrypted are 'aa'
  * so with the same IV it should always be encrypted to the same thing.
  */
-int list_check_decloak(struct pkt_buf **list, int length, unsigned char* packet)
+static int list_check_decloak(struct pkt_buf **list, int length, unsigned char* packet)
 {
     struct pkt_buf *next = *list;
     struct timeval tv1;
@@ -1184,7 +1186,7 @@ int list_check_decloak(struct pkt_buf **list, int length, unsigned char* packet)
     return 1; //didn't find decloak
 }
 
-int remove_namac(unsigned char* mac)
+static int remove_namac(unsigned char* mac)
 {
     struct NA_info *na_cur = NULL;
     struct NA_info *na_prv = NULL;
@@ -1223,7 +1225,7 @@ int remove_namac(unsigned char* mac)
     return( 0 );
 }
 
-int dump_add_packet( unsigned char *h80211, int caplen, struct rx_info *ri, int cardnum )
+static int dump_add_packet( unsigned char *h80211, int caplen, struct rx_info *ri, int cardnum )
 {
     int i, n, seq, msd, dlen, offset, clen, o;
     unsigned z;
@@ -2635,7 +2637,7 @@ write_packet:
     return( 0 );
 }
 
-void dump_sort( void )
+void dump_sort(void)
 {
     time_t tt = time( NULL );
 
@@ -2824,12 +2826,12 @@ void dump_sort( void )
     G.st_end = new_st_end;
 }
 
-int getBatteryState()
+static int getBatteryState(void)
 {
 	return get_battery_state();
 }
 
-char * getStringTimeFromSec(double seconds)
+static char * getStringTimeFromSec(double seconds)
 {
     int hour[3];
     char * ret;
@@ -2872,7 +2874,7 @@ char * getStringTimeFromSec(double seconds)
 
 }
 
-char * getBatteryString(void)
+static char * getBatteryString(void)
 {
     int batt_time;
     char * ret;
@@ -2897,7 +2899,7 @@ char * getBatteryString(void)
     return ret;
 }
 
-int get_ap_list_count() {
+static int get_ap_list_count(void) {
     time_t tt;
     struct tm *lt;
     struct AP_info *ap_cur;
@@ -2942,7 +2944,7 @@ int get_ap_list_count() {
     return num_ap;
 }
 
-int get_sta_list_count() {
+static int get_sta_list_count(void) {
     time_t tt;
     struct tm *lt;
     struct AP_info *ap_cur;
@@ -3678,7 +3680,7 @@ void dump_print( int ws_row, int ws_col, int if_num )
     }
 }
 
-char * format_text_for_csv( const unsigned char * input, int len)
+static char * format_text_for_csv( const unsigned char * input, int len)
 {
 	// Unix style encoding
 	char * ret;
@@ -3743,7 +3745,7 @@ char * format_text_for_csv( const unsigned char * input, int len)
 	return ret;
 }
 
-int dump_write_csv( void )
+static int dump_write_csv( void )
 {
     int i, n, probes_written;
     struct tm *ltime;
@@ -3951,7 +3953,7 @@ int dump_write_csv( void )
     return 0;
 }
 
-char * sanitize_xml(unsigned char * text, int length)
+static char * sanitize_xml(unsigned char * text, int length)
 {
 	int i;
 	size_t len, current_text_len;
@@ -4005,7 +4007,7 @@ char * sanitize_xml(unsigned char * text, int length)
 
 #define OUI_STR_SIZE 8
 #define MANUF_SIZE 128
-char *get_manufacturer(unsigned char mac0, unsigned char mac1, unsigned char mac2) {
+static char *get_manufacturer(unsigned char mac0, unsigned char mac1, unsigned char mac2) {
 	char oui[OUI_STR_SIZE + 1];
 	char *manuf;
 	//char *buffer_manuf;
@@ -4092,7 +4094,7 @@ char *get_manufacturer(unsigned char mac0, unsigned char mac1, unsigned char mac
 #define KISMET_NETXML_TRAILER "</detection-run>"
 
 #define TIME_STR_LENGTH 255
-int dump_write_kismet_netxml_client_info(struct ST_info *client, int client_no)
+static int dump_write_kismet_netxml_client_info(struct ST_info *client, int client_no)
 {
 	char first_time[TIME_STR_LENGTH];
 	char last_time[TIME_STR_LENGTH];
@@ -4242,7 +4244,7 @@ int dump_write_kismet_netxml_client_info(struct ST_info *client, int client_no)
 }
 
 #define NETXML_ENCRYPTION_TAG "%s<encryption>%s</encryption>\n"
-int dump_write_kismet_netxml( void )
+static int dump_write_kismet_netxml( void )
 {
     int network_number, average_power, client_max_rate, max_power, client_nbr, unused;
     struct AP_info *ap_cur;
@@ -4609,7 +4611,7 @@ int dump_write_kismet_netxml( void )
 #define KISMET_HEADER "Network;NetType;ESSID;BSSID;Info;Channel;Cloaked;Encryption;Decrypted;MaxRate;MaxSeenRate;Beacon;LLC;Data;Crypt;Weak;Total;Carrier;Encoding;FirstTime;LastTime;BestQuality;BestSignal;BestNoise;GPSMinLat;GPSMinLon;GPSMinAlt;GPSMinSpd;GPSMaxLat;GPSMaxLon;GPSMaxAlt;GPSMaxSpd;GPSBestLat;GPSBestLon;GPSBestAlt;DataSize;IPType;IP;\n"
 
 
-int dump_write_kismet_csv( void )
+static int dump_write_kismet_csv( void )
 {
     int i, k;
 //     struct tm *ltime;
@@ -4987,7 +4989,7 @@ static int json_get_value_for_name( const char *buffer, const char *name, char *
 	return ret;
 }
 
-void gps_tracker(pid_t parent)
+static void gps_tracker(pid_t parent)
 {
 	ssize_t unused;
     int gpsd_sock;
@@ -5208,7 +5210,7 @@ void gps_tracker(pid_t parent)
     }
 }
 
-void sighandler( int signum)
+static void sighandler( int signum)
 {
 	ssize_t unused;
 	int card = 0;
@@ -5270,7 +5272,7 @@ void sighandler( int signum)
 	}
 }
 
-int send_probe_request(struct wif *wi)
+static int send_probe_request(struct wif *wi)
 {
     int len;
     unsigned char p[4096], r_smac[6];
@@ -5312,7 +5314,7 @@ int send_probe_request(struct wif *wi)
     return 0;
 }
 
-int send_probe_requests(struct wif *wi[], int cards)
+static int send_probe_requests(struct wif *wi[], int cards)
 {
     int i=0;
     for(i=0; i<cards; i++)
@@ -5322,7 +5324,7 @@ int send_probe_requests(struct wif *wi[], int cards)
     return 0;
 }
 
-int getchancount(int valid)
+static int getchancount(int valid)
 {
     int i=0, chan_count=0;
 
@@ -5337,7 +5339,7 @@ int getchancount(int valid)
     return i;
 }
 
-int getfreqcount(int valid)
+static int getfreqcount(int valid)
 {
     int i=0, freq_count=0;
 
@@ -5352,7 +5354,7 @@ int getfreqcount(int valid)
     return i;
 }
 
-void channel_hopper(struct wif *wi[], int if_num, int chan_count, pid_t parent)
+static void channel_hopper(struct wif *wi[], int if_num, int chan_count, pid_t parent)
 {
 	ssize_t unused;
     int ch, ch_idx = 0, card=0, chi=0, cai=0, j=0, k=0, first=1, again=1;
@@ -5450,7 +5452,7 @@ void channel_hopper(struct wif *wi[], int if_num, int chan_count, pid_t parent)
     exit( 0 );
 }
 
-void frequency_hopper(struct wif *wi[], int if_num, int chan_count, pid_t parent)
+static void frequency_hopper(struct wif *wi[], int if_num, int chan_count, pid_t parent)
 {
 	ssize_t unused;
     int ch, ch_idx = 0, card=0, chi=0, cai=0, j=0, k=0, first=1, again=1;
@@ -5546,7 +5548,7 @@ void frequency_hopper(struct wif *wi[], int if_num, int chan_count, pid_t parent
     exit( 0 );
 }
 
-int invalid_channel(int chan)
+static int invalid_channel(int chan)
 {
     int i=0;
 
@@ -5558,7 +5560,7 @@ int invalid_channel(int chan)
     return 1;
 }
 
-int invalid_frequency(int freq)
+static int invalid_frequency(int freq)
 {
     int i=0;
 
@@ -5572,7 +5574,7 @@ int invalid_frequency(int freq)
 
 /* parse a string, for example "1,2,3-7,11" */
 
-int getchannels(const char *optarg)
+static int getchannels(const char *optarg)
 {
     unsigned int i=0,chan_cur=0,chan_first=0,chan_last=0,chan_max=128,chan_remain=0;
     char *optchan = NULL, *optc;
@@ -5693,7 +5695,7 @@ int getchannels(const char *optarg)
 
 /* parse a string, for example "1,2,3-7,11" */
 
-int getfrequencies(const char *optarg)
+static int getfrequencies(const char *optarg)
 {
     unsigned int i=0,freq_cur=0,freq_first=0,freq_last=0,freq_max=10000,freq_remain=0;
     char *optfreq = NULL, *optc;
@@ -5827,7 +5829,7 @@ int getfrequencies(const char *optarg)
     return 0;                               //frequency hopping
 }
 
-int setup_card(char *iface, struct wif **wis)
+static int setup_card(char *iface, struct wif **wis)
 {
 	struct wif *wi;
 
@@ -5839,7 +5841,7 @@ int setup_card(char *iface, struct wif **wis)
 	return 0;
 }
 
-int init_cards(const char* cardstr, char *iface[], struct wif **wi)
+static int init_cards(const char* cardstr, char *iface[], struct wif **wi)
 {
     char *buffer;
     char *buf;
@@ -5872,7 +5874,7 @@ int init_cards(const char* cardstr, char *iface[], struct wif **wi)
 }
 
 #if 0
-int get_if_num(const char* cardstr)
+static int get_if_num(const char* cardstr)
 {
     char *buffer;
     int if_count=0;
@@ -5896,7 +5898,7 @@ int get_if_num(const char* cardstr)
 }
 #endif
 
-int set_encryption_filter(const char* input)
+static int set_encryption_filter(const char* input)
 {
     if(input == NULL) return 1;
 
@@ -5923,7 +5925,7 @@ int set_encryption_filter(const char* input)
     return 0;
 }
 
-int check_monitor(struct wif *wi[], int *fd_raw, int *fdh, int cards)
+static int check_monitor(struct wif *wi[], int *fd_raw, int *fdh, int cards)
 {
     int i, monitor;
     char ifname[64];
@@ -5955,7 +5957,7 @@ int check_monitor(struct wif *wi[], int *fd_raw, int *fdh, int cards)
     return 0;
 }
 
-int check_channel(struct wif *wi[], int cards)
+static int check_channel(struct wif *wi[], int cards)
 {
     int i, chan;
     for(i=0; i<cards; i++)
@@ -5972,7 +5974,7 @@ int check_channel(struct wif *wi[], int cards)
     return 0;
 }
 
-int check_frequency(struct wif *wi[], int cards)
+static int check_frequency(struct wif *wi[], int cards)
 {
     int i, freq;
     for(i=0; i<cards; i++)
@@ -5989,7 +5991,7 @@ int check_frequency(struct wif *wi[], int cards)
     return 0;
 }
 
-int detect_frequencies(struct wif *wi)
+static int detect_frequencies(struct wif *wi)
 {
     int start_freq = 2192;
     int end_freq = 2732;
@@ -6036,7 +6038,7 @@ int detect_frequencies(struct wif *wi)
     return 0;
 }
 
-int array_contains(int *array, int length, int value)
+static int array_contains(int *array, int length, int value)
 {
     int i;
     for(i=0;i<length;i++)
@@ -6046,7 +6048,7 @@ int array_contains(int *array, int length, int value)
     return 0;
 }
 
-int rearrange_frequencies()
+static int rearrange_frequencies(void)
 {
     int *freqs;
     int count, left, pos;

--- a/src/airodump-ng.h
+++ b/src/airodump-ng.h
@@ -120,7 +120,6 @@
 extern char * getVersion(char * progname, int maj, int min, int submin, int svnrev, int beta, int rc);
 extern unsigned char * getmac(char * macAddress, int strict, unsigned char * mac);
 extern int get_ram_size(void);
-char *get_manufacturer(unsigned char mac0, unsigned char mac1, unsigned char mac2);
 
 #define AIRODUMP_NG_CSV_EXT "csv"
 #define KISMET_CSV_EXT "kismet.csv"

--- a/src/airserv-ng.c
+++ b/src/airserv-ng.c
@@ -44,7 +44,7 @@
 
 extern char * getVersion(char * progname, int maj, int min, int submin, int svnrev, int beta, int rc);
 
-void sighandler( int signum )
+static void sighandler( int signum )
 {
     if( signum == SIGPIPE )
         printf("broken pipe!\n");
@@ -65,7 +65,7 @@ static struct sstate {
 	int		ss_level;
 } _ss;
 
-static struct sstate *get_ss()
+static struct sstate *get_ss(void)
 {
 	return &_ss;
 }

--- a/src/airtun-ng.c
+++ b/src/airtun-ng.c
@@ -210,7 +210,7 @@ char * iwpriv;
 
 pFrag_t     rFragment;
 
-struct net_entry *find_entry(unsigned char *adress) {
+static struct net_entry *find_entry(unsigned char *adress) {
     struct net_entry *cur = nets;
 
     if (cur == NULL) return NULL;
@@ -225,7 +225,7 @@ struct net_entry *find_entry(unsigned char *adress) {
     return NULL;
 }
 
-void set_entry(unsigned char *adress, unsigned char network) {
+static void set_entry(unsigned char *adress, unsigned char network) {
     struct net_entry *cur;
 
     if( nets == NULL ) {
@@ -247,7 +247,7 @@ void set_entry(unsigned char *adress, unsigned char network) {
     cur->net = network;
 }
 
-int get_entry(unsigned char *adress) {
+static int get_entry(unsigned char *adress) {
     struct net_entry *cur = find_entry(adress);
 
     if (cur == NULL) {
@@ -257,7 +257,7 @@ int get_entry(unsigned char *adress) {
     }
 }
 
-void swap_ra_ta(unsigned char *h80211) {
+static void swap_ra_ta(unsigned char *h80211) {
      unsigned char mbuf[6];
 
      memcpy(mbuf     , h80211+ 4, 6);
@@ -265,7 +265,7 @@ void swap_ra_ta(unsigned char *h80211) {
      memcpy(h80211+10, mbuf     , 6);
 }
 
-void sighandler( int signum )
+static void sighandler( int signum )
 {
     if( signum == SIGINT )
         ctrl_c++;
@@ -274,7 +274,7 @@ void sighandler( int signum )
         alarmed++;
 }
 
-int addFrag(unsigned char* packet, unsigned char* smac, int len)
+static int addFrag(unsigned char* packet, unsigned char* smac, int len)
 {
     pFrag_t cur = rFragment;
     int seq, frag, wep, z, i;
@@ -396,7 +396,7 @@ int addFrag(unsigned char* packet, unsigned char* smac, int len)
     return 0;
 }
 
-int timeoutFrag()
+static int timeoutFrag(void)
 {
     pFrag_t old, cur = rFragment;
     struct timeval tv;
@@ -429,7 +429,7 @@ int timeoutFrag()
     return 0;
 }
 
-int delFrag(unsigned char* smac, int sequence)
+static int delFrag(unsigned char* smac, int sequence)
 {
     pFrag_t old, cur = rFragment;
     int i;
@@ -464,7 +464,7 @@ int delFrag(unsigned char* smac, int sequence)
     return 0;
 }
 
-unsigned char* getCompleteFrag(unsigned char* smac, int sequence, int *packetlen)
+static unsigned char* getCompleteFrag(unsigned char* smac, int sequence, int *packetlen)
 {
     pFrag_t old, cur = rFragment;
     int i, len=0;
@@ -558,7 +558,7 @@ unsigned char* getCompleteFrag(unsigned char* smac, int sequence, int *packetlen
     return packet;
 }
 
-int is_filtered_netmask(unsigned char *bssid)
+static int is_filtered_netmask(unsigned char *bssid)
 {
     unsigned char mac1[6];
     unsigned char mac2[6];
@@ -578,7 +578,7 @@ int is_filtered_netmask(unsigned char *bssid)
     return 0;
 }
 
-int send_packet(void *buf, size_t count)
+static int send_packet(void *buf, size_t count)
 {
         struct wif *wi = _wi_out; /* XXX globals suck */
         if (wi_write(wi, buf, count, NULL) == -1) {
@@ -590,7 +590,7 @@ int send_packet(void *buf, size_t count)
         return 0;
 }
 
-int read_packet(void *buf, size_t count)
+static int read_packet(void *buf, size_t count)
 {
         struct wif *wi = _wi_in; /* XXX */
         int rc;
@@ -604,7 +604,7 @@ int read_packet(void *buf, size_t count)
         return rc;
 }
 
-int msleep( int msec )
+static int msleep( int msec )
 {
     struct timeval tv, tv2;
     float f, ticks;
@@ -652,7 +652,7 @@ int msleep( int msec )
     return 0;
 }
 
-int read_prga(unsigned char **dest, char *file)
+static int read_prga(unsigned char **dest, char *file)
 {
     FILE *f;
     int size;
@@ -697,7 +697,7 @@ int read_prga(unsigned char **dest, char *file)
     return( 0 );
 }
 
-void add_icv(unsigned char *input, int len, int offset)
+static void add_icv(unsigned char *input, int len, int offset)
 {
     unsigned long crc = 0xFFFFFFFF;
     int n=0;
@@ -715,7 +715,7 @@ void add_icv(unsigned char *input, int len, int offset)
     return;
 }
 
-int xor_keystream(unsigned char *ph80211, unsigned char *keystream, int len)
+static int xor_keystream(unsigned char *ph80211, unsigned char *keystream, int len)
 {
     int i=0;
 
@@ -726,7 +726,7 @@ int xor_keystream(unsigned char *ph80211, unsigned char *keystream, int len)
     return 0;
 }
 
-void print_packet ( unsigned char h80211[], int caplen )
+static void print_packet ( unsigned char h80211[], int caplen )
 {
 	int i,j;
 	int key_index_offset=0;
@@ -797,7 +797,7 @@ void print_packet ( unsigned char h80211[], int caplen )
     "\x08\x00\x00\x00\xDD\xDD\xDD\xDD\xDD\xDD\xBB\xBB\xBB\xBB\xBB\xBB"  \
     "\xCC\xCC\xCC\xCC\xCC\xCC\xE0\x32\xAA\xAA\x03\x00\x00\x00\x08\x00"
 
-int set_IVidx(unsigned char* packet, int data_begin)
+static int set_IVidx(unsigned char* packet, int data_begin)
 {
     if(packet == NULL) return 1;
 
@@ -813,7 +813,7 @@ int set_IVidx(unsigned char* packet, int data_begin)
     return 0;
 }
 
-int encrypt_data(unsigned char *dest, unsigned char* data, int length)
+static int encrypt_data(unsigned char *dest, unsigned char* data, int length)
 {
     unsigned char cipher[2048];
     int n;
@@ -845,7 +845,7 @@ int encrypt_data(unsigned char *dest, unsigned char* data, int length)
     return 0;
 }
 
-int create_wep_packet(unsigned char* packet, int *length, int data_begin)
+static int create_wep_packet(unsigned char* packet, int *length, int data_begin)
 {
     if(packet == NULL) return 1;
 
@@ -867,7 +867,7 @@ int create_wep_packet(unsigned char* packet, int *length, int data_begin)
     return 0;
 }
 
-int packet_xmit(unsigned char* packet, int length)
+static int packet_xmit(unsigned char* packet, int length)
 {
     unsigned char K[64];
     unsigned char buf[4096];
@@ -1005,7 +1005,7 @@ int packet_xmit(unsigned char* packet, int length)
 }
 
 
-int packet_recv(unsigned char* packet, int length)
+static int packet_recv(unsigned char* packet, int length)
 {
     unsigned char K[64];
     unsigned char bssid[6], smac[6], dmac[6], stmac[6];

--- a/src/airventriloquist-ng.c
+++ b/src/airventriloquist-ng.c
@@ -291,7 +291,7 @@ int ctrl_c, alarmed;
 char * iwpriv;
 
 
-void sighandler( int signum )
+static void sighandler( int signum )
 {
     if( signum == SIGINT )
         ctrl_c++;
@@ -300,7 +300,7 @@ void sighandler( int signum )
         alarmed++;
 }
 
-int reset_ifaces()
+static int reset_ifaces(void)
 {
     //close interfaces
     if(_wi_in != _wi_out)
@@ -356,7 +356,7 @@ int reset_ifaces()
     return 0;
 }
 
-int set_bitrate(struct wif *wi, int rate)
+static int set_bitrate(struct wif *wi, int rate)
 {
     int i, newrate;
 
@@ -408,19 +408,19 @@ int set_bitrate(struct wif *wi, int rate)
     return 0;
 }
 
-uint32_t calc_fcs(const uint8_t *buf, uint32_t len)
+static uint32_t calc_fcs(const uint8_t *buf, uint32_t len)
 {
   uint i;
   uint32_t crc32 = 0xFFFFFFFF; //Seed
- 
+
   for (i = 0; i < len; i++)
   crc32 = crc32_ccitt_table[(crc32 ^ buf[i]) & 0xff] ^ (crc32 >> 8);
- 
+
   return ( ~crc32 );
 }
 
 
-int send_packet(void *buf, u_int32_t count)
+static int send_packet(void *buf, u_int32_t count)
 {
     struct wif *wi = _wi_out; /* XXX globals suck */
     u_int8_t *pkt = (u_int8_t*) buf;
@@ -443,7 +443,7 @@ int send_packet(void *buf, u_int32_t count)
         //Set the duration...
         pkt[2] = 0x3A;
         pkt[3] = 0x01;
-        
+
         //Reset Retry Flag
         pkt[1] = pkt[1] & ~0x4;
     }
@@ -465,7 +465,7 @@ int send_packet(void *buf, u_int32_t count)
     return 0;
 }
 
-int read_packet(void *buf, u_int32_t count, struct rx_info *ri)
+static int read_packet(void *buf, u_int32_t count, struct rx_info *ri)
 {
     struct wif *wi = _wi_in; /* XXX */
     int rc;
@@ -484,7 +484,7 @@ int read_packet(void *buf, u_int32_t count, struct rx_info *ri)
     return rc;
 }
 
-void read_sleep( int usec )
+static void read_sleep( int usec )
 {
     struct timeval tv, tv2, tv3;
     int caplen;
@@ -514,7 +514,7 @@ void read_sleep( int usec )
 }
 
 /*
-int filter_packet( u_int8_t *h80211, int caplen )
+static int filter_packet( u_int8_t *h80211, int caplen )
 {
     int z, mi_b, mi_s, mi_d, ext=0, qos;
 
@@ -585,7 +585,7 @@ int filter_packet( u_int8_t *h80211, int caplen )
 }
 */
 
-int wait_for_beacon(uint8_t *bssid, uint8_t *capa, char *essid)
+static int wait_for_beacon(uint8_t *bssid, uint8_t *capa, char *essid)
 {
     int len = 0, chan = 0, taglen = 0, tagtype = 0, pos = 0;
     uint8_t pkt_sniff[4096];
@@ -697,7 +697,7 @@ int wait_for_beacon(uint8_t *bssid, uint8_t *capa, char *essid)
 /**
     if bssid != NULL its looking for a beacon frame
 */
-int attack_check(uint8_t* bssid, char* essid, uint8_t* capa, struct wif *wi)
+static int attack_check(uint8_t* bssid, char* essid, uint8_t* capa, struct wif *wi)
 {
     int ap_chan=0, iface_chan=0;
 
@@ -728,7 +728,7 @@ int attack_check(uint8_t* bssid, char* essid, uint8_t* capa, struct wif *wi)
     return 0;
 }
 
-int getnet( uint8_t* capa, int filter, int force)
+static int getnet( uint8_t* capa, int filter, int force)
 {
     u_int8_t *bssid;
 
@@ -820,7 +820,7 @@ out:
     return port;
 }
 
-int tcp_test(const char* ip_str, const short port)
+static int tcp_test(const char* ip_str, const short port)
 {
     int sock, i;
     struct sockaddr_in s_in;
@@ -1029,7 +1029,7 @@ int tcp_test(const char* ip_str, const short port)
 
 //TODO: this function is hacked together, It should be cleaned up
 // Need to use wfrm (ieee80211_frame struct instead of just a buffer)
-int deauth_station( struct WPA_ST_info *st_cur )
+static int deauth_station( struct WPA_ST_info *st_cur )
 {
     if( memcmp( st_cur->stmac, NULL_MAC, 6 ) != 0 )
     {
@@ -1055,7 +1055,7 @@ int deauth_station( struct WPA_ST_info *st_cur )
                 return( 1 );
 
             //usleep(2000);
-            
+
             //Send deauth to the AP...
             memcpy( h80211 +  4, st_cur->bssid, 6 );
             memcpy( h80211 + 10, st_cur->stmac,  6 );
@@ -1074,7 +1074,7 @@ int deauth_station( struct WPA_ST_info *st_cur )
 
 
 //Shameless copy from tshark/wireshark?
-void hexDump (char* desc, void *addr, int len) {
+static void hexDump (char* desc, void *addr, int len) {
     int i;
     u_int8_t buff[17];
     u_int8_t *pc = (u_int8_t*)addr;
@@ -1120,7 +1120,7 @@ void hexDump (char* desc, void *addr, int len) {
 /* calcsum - used to calculate IP and ICMP header checksums using
  * one's compliment of the one's compliment sum of 16 bit words of the header
  */
-u_int16_t calcsum(u_int16_t *buffer, u_int32_t length)
+static u_int16_t calcsum(u_int16_t *buffer, u_int32_t length)
 {
     u_int32_t sum;  
 
@@ -1138,7 +1138,7 @@ u_int16_t calcsum(u_int16_t *buffer, u_int32_t length)
 }
 //This needs to be cleaned up so that we can do UDP/TCP in one function. Don't want to do that now and risk
 // breaking UDP checksums right now
-u_int16_t calcsum_tcp(u_int16_t *buf, u_int32_t len, u_int32_t src_addr, u_int32_t dest_addr)
+static u_int16_t calcsum_tcp(u_int16_t *buf, u_int32_t len, u_int32_t src_addr, u_int32_t dest_addr)
 {
         u_int32_t chksum;
         u_int32_t length=len;
@@ -1177,7 +1177,7 @@ u_int16_t calcsum_tcp(u_int16_t *buf, u_int32_t len, u_int32_t src_addr, u_int32
         return ((u_int16_t)(~chksum));
 }
 
-u_int16_t calcsum_udp(u_int16_t *buf, u_int32_t len, u_int32_t src_addr, u_int32_t dest_addr)
+static u_int16_t calcsum_udp(u_int16_t *buf, u_int32_t len, u_int32_t src_addr, u_int32_t dest_addr)
 {
         u_int32_t chksum;
         u_int32_t length=len;
@@ -1252,7 +1252,7 @@ static inline u_int8_t* packet_get_bssid_80211( u_int8_t* pkt )
     return NULL;
 }
 
-void packet_turnaround_80211( u_int8_t* pkt )
+static void packet_turnaround_80211( u_int8_t* pkt )
 {
     struct ieee80211_frame *p_res802 = (struct ieee80211_frame *)pkt;
     u_int8_t tmp_mac[IEEE80211_ADDR_LEN] = {0};
@@ -1278,7 +1278,7 @@ void packet_turnaround_80211( u_int8_t* pkt )
     return;
 }
 
-void packet_turnaround_ip( struct ip_frame *p_resip )
+static void packet_turnaround_ip( struct ip_frame *p_resip )
 { 
     //Switch the IP source and destination addresses
     u_int32_t tmp_addr = p_resip->saddr;
@@ -1287,7 +1287,7 @@ void packet_turnaround_ip( struct ip_frame *p_resip )
     p_resip->ttl = 63;
 }
 
-void packet_turnaround_ip_udp( struct udp_hdr *p_resudp )
+static void packet_turnaround_ip_udp( struct udp_hdr *p_resudp )
 { 
     //Switch the UDP source and destination Ports
     u_int16_t tmp_port = p_resudp->sport;
@@ -1295,7 +1295,7 @@ void packet_turnaround_ip_udp( struct udp_hdr *p_resudp )
     p_resudp->dport = tmp_port;
 }
 
-void packet_turnaround_ip_tcp( struct tcp_hdr *p_restcp, u_int32_t next_seq_hint )
+static void packet_turnaround_ip_tcp( struct tcp_hdr *p_restcp, u_int32_t next_seq_hint )
 { 
     //Switch the TCP source and destination Ports
     u_int16_t tmp_port = p_restcp->sport;
@@ -1312,7 +1312,7 @@ void packet_turnaround_ip_tcp( struct tcp_hdr *p_restcp, u_int32_t next_seq_hint
     p_restcp->ack_seq = htonl(tmp_num);
 }
 
-u_int16_t dns_name_end( u_int8_t* buff, u_int16_t maxlen )
+static u_int16_t dns_name_end( u_int8_t* buff, u_int16_t maxlen )
 {
     u_int8_t *ptr = buff;
     u_int8_t count = 0;
@@ -1331,7 +1331,7 @@ u_int16_t dns_name_end( u_int8_t* buff, u_int16_t maxlen )
     return offset;
 }
 
-int strip_ccmp_header(u_int8_t* h80211, int caplen, unsigned char PN[6])
+static int strip_ccmp_header(u_int8_t* h80211, int caplen, unsigned char PN[6])
 {
     int is_a4, z, is_qos;
 
@@ -1355,7 +1355,7 @@ int strip_ccmp_header(u_int8_t* h80211, int caplen, unsigned char PN[6])
     return caplen - 16;
 }
 
-void encrypt_data_packet(u_int8_t* packet, int length, struct WPA_ST_info* sta_cur )
+static void encrypt_data_packet(u_int8_t* packet, int length, struct WPA_ST_info* sta_cur )
 {
     if ( (NULL == sta_cur) || (! sta_cur->valid_ptk) )  { return; }
     else
@@ -1384,7 +1384,7 @@ void encrypt_data_packet(u_int8_t* packet, int length, struct WPA_ST_info* sta_c
 //Global packet buffer for use in building response packets
 uint8_t pkt[2048] = {0};
 
-void process_unencrypted_data_packet(u_int8_t* packet, u_int32_t length, u_int32_t debug)
+static void process_unencrypted_data_packet(u_int8_t* packet, u_int32_t length, u_int32_t debug)
 {
     if (debug) hexDump("full", packet, length);
     
@@ -1824,7 +1824,7 @@ void process_unencrypted_data_packet(u_int8_t* packet, u_int32_t length, u_int32
 }
 
 
-bool is_adhoc_frame(u_int8_t* packet)
+static bool is_adhoc_frame(u_int8_t* packet)
 {
     u_int8_t *p_stmac = packet_get_sta_80211(packet);
 
@@ -1832,7 +1832,7 @@ bool is_adhoc_frame(u_int8_t* packet)
     else                 { return FALSE; }
 }
 
-bool find_station_in_db(u_int8_t *p_stmac)
+static bool find_station_in_db(u_int8_t *p_stmac)
 {
     opt.st_prv = NULL;
     opt.st_cur = opt.st_1st;
@@ -1854,7 +1854,7 @@ bool find_station_in_db(u_int8_t *p_stmac)
         return TRUE;
 }
 
-bool alloc_new_station_in_db()
+static bool alloc_new_station_in_db(void)
 {
     opt.st_cur = (struct WPA_ST_info *)malloc( sizeof(struct WPA_ST_info) );
 
@@ -1885,7 +1885,7 @@ static inline bool mac_is_multi_broadcast(unsigned char stmac[6])
     return FALSE;
 }
 
-void process_station_data(u_int8_t* packet, int length)
+static void process_station_data(u_int8_t* packet, int length)
 {
     if (is_length_lt_wfrm(length)) return;
 
@@ -1945,7 +1945,7 @@ static inline bool is_wfrm_qos(struct ieee80211_frame* wfrm)
     return (IEEE80211_FC0_SUBTYPE_QOS & wfrm->i_fc[0]);
 }
 
-bool is_wfrm_already_processed(u_int8_t* packet, int length)
+static bool is_wfrm_already_processed(u_int8_t* packet, int length)
 {
     struct ieee80211_frame* wfrm = (struct ieee80211_frame*)packet;
 
@@ -1969,7 +1969,7 @@ bool is_wfrm_already_processed(u_int8_t* packet, int length)
     return FALSE;
 }
 
-struct llc_frame* find_llc_frm_ptr(u_int8_t* packet, int length)
+static struct llc_frame* find_llc_frm_ptr(u_int8_t* packet, int length)
 {
     if (is_length_lt_wfrm(length)) return NULL;
 
@@ -1980,7 +1980,7 @@ struct llc_frame* find_llc_frm_ptr(u_int8_t* packet, int length)
     return p_llc;
 }
 
-void process_wireless_data_packet(u_int8_t* packet, int length)
+static void process_wireless_data_packet(u_int8_t* packet, int length)
 {
     u_int8_t* packet_start = packet;
     int packet_start_length = length;
@@ -2063,7 +2063,7 @@ void process_wireless_data_packet(u_int8_t* packet, int length)
 
 }
 
-void process_wireless_packet(u_int8_t* packet, int length)
+static void process_wireless_packet(u_int8_t* packet, int length)
 {
     struct ieee80211_frame* wfrm = (struct ieee80211_frame*)packet;
     short fc =  *wfrm->i_fc;
@@ -2075,7 +2075,7 @@ void process_wireless_packet(u_int8_t* packet, int length)
     return;
 }
 
-int do_active_injection()
+static int do_active_injection(void)
 {
     struct timeval tv;
     fd_set rfds;

--- a/src/besside-ng-crawler.c
+++ b/src/besside-ng-crawler.c
@@ -64,23 +64,23 @@ struct bsslist {
 };
 
 
-struct bsslist *is_in_list(struct bsslist *bsl, const u_char *bssid) {
+static struct bsslist *is_in_list(struct bsslist *bsl, const u_char *bssid) {
 
   while (bsl != NULL) {
     if (! memcmp(bsl->bssid, bssid, 6)) return bsl;
     bsl = bsl->next;
   }
-  
+
   return NULL;
 }
 
 
-struct bsslist *add_to_list(struct bsslist *bsl, const u_char *bssid) {
+static struct bsslist *add_to_list(struct bsslist *bsl, const u_char *bssid) {
   struct bsslist *new, *search;
-  
+
   new= malloc(sizeof(struct bsslist));
   new->bssid = malloc(6);
-    
+
   memcpy(new->bssid, bssid, 6);
   new->next = NULL;
   new->beacon_saved = 0x00;
@@ -96,22 +96,22 @@ struct bsslist *add_to_list(struct bsslist *bsl, const u_char *bssid) {
 }
 
 
-void free_bsslist(struct bsslist *bsl) {
+static void free_bsslist(struct bsslist *bsl) {
   if (! bsl) return;
-  
+
   if (bsl->next) free_bsslist(bsl->next);
-  
+
   free(bsl->bssid);
   free(bsl);
 }
 
 
-struct bsslist *get_eapol_bssids(pcap_t *handle) {
+static struct bsslist *get_eapol_bssids(pcap_t *handle) {
   struct pcap_pkthdr header;
   const u_char *pkt, *llc, *bssid, *offset = NULL;
   struct bsslist *bsl = NULL;
   int o = 0;
-  
+
   pkt = pcap_next(handle, &header);
 
   if (pcap_datalink(handle) == DLT_PRISM_HEADER) {
@@ -125,29 +125,29 @@ struct bsslist *get_eapol_bssids(pcap_t *handle) {
       offset = pkt + 4;
     }
   }
-  
+
   while (pkt != NULL) {
     stats_packets++;
-    
+
     if (offset) o = (*offset);
-    
+
     if ((pkt[0+o] == 0x08) || (pkt[0+o] == 0x88)) { //Data or QoS Data
-      
+
       if (pkt[0+o] == 0x88) { //Qos Data has 2 bytes extra in header
 	llc = pkt + 26 + o;
       } else {
 	llc = pkt + 24 + o;
       }
-      
+
       if ((pkt[1+o] & 0x03) == 0x01) { //toDS
 	bssid = pkt + 4 + o;
       } else {	//fromDS - I skip adhoc and wds since its unlikely to have eapol in there (?)
 	bssid = pkt + 10 + o;
       }
-      
+
       if (! memcmp(llc, "\xaa\xaa\x03\x00\x00\x00\x88\x8e", 8)) {
 	stats_eapols++;
-	
+
 	if (! is_in_list(bsl, bssid)) {
 	  printf("EAPOL found for BSSID: %02X:%02X:%02X:%02X:%02X:%02X\n", bssid[0], bssid[1], bssid[2], bssid[3], bssid[4], bssid[5]);
 	  bsl = add_to_list(bsl, bssid);
@@ -155,22 +155,22 @@ struct bsslist *get_eapol_bssids(pcap_t *handle) {
 	}
       }
     }
-    
+
     pkt = pcap_next(handle, &header);
   }
-  
+
   return bsl;
 }
 
 
-void process_eapol_networks(pcap_t *handle, struct bsslist *bsl) {
+static void process_eapol_networks(pcap_t *handle, struct bsslist *bsl) {
   struct pcap_pkthdr header;
   const u_char *pkt, *llc, *bssid, *offset = 0;
   struct bsslist *known;
   int o = 0;
-  
+
   pkt = pcap_next(handle, &header);
-  
+
   if (pcap_datalink(handle) == DLT_PRISM_HEADER) {
     if (pkt[7] == 0x40) { //prism54 format
       offset = pkt + 7;
@@ -178,12 +178,12 @@ void process_eapol_networks(pcap_t *handle, struct bsslist *bsl) {
       offset = pkt + 4;
     }
   }
-  
+
   while (pkt != NULL) {
-    
+
     if (offset) o = (*offset);
     header.len -= o;
-    
+
     if ((pkt[0+o] == 0x08) || (pkt[0+o] == 0x88) || (pkt[0+o] == 0x80)) {
 
       if ((pkt[1+o] & 0x03) == 0x01) { //toDS
@@ -193,26 +193,26 @@ void process_eapol_networks(pcap_t *handle, struct bsslist *bsl) {
       } else {	//fromDS
 	bssid = pkt + 10 + o;
       }
-      
+
       if (pkt[0+o] == 0x80) {	//beacon
 	known = is_in_list(bsl, bssid);
 	if (!known || known->beacon_saved) {
 	  pkt = pcap_next(handle, &header);
 	  continue;
 	}
-	
+
 	//Saving ONE beacon per WPA network
 	pcap_dump((u_char *) dumper, &header, pkt + o);
 	known->beacon_saved = 0x01;
       }
-      
+
       if (pkt[0+o] == 0x88) {
 	//printf("QoS Data\n");
 	llc = pkt + 26 + o;
       } else {
 	llc = pkt + 24 + o;
       }
-      
+
       if (! memcmp(llc, "\xaa\xaa\x03\x00\x00\x00\x88\x8e", 8)) {
 	if (is_in_list(bsl, bssid)) {
 	  // Saving EAPOL
@@ -220,77 +220,77 @@ void process_eapol_networks(pcap_t *handle, struct bsslist *bsl) {
 	}
       }
     }
-    
+
     pkt = pcap_next(handle, &header);
   }
 }
 
 
-void process_file(const char *file) {
+static void process_file(const char *file) {
   pcap_t *handle;
   char errbuf[PCAP_ERRBUF_SIZE];
   struct bsslist *eapol_networks = NULL;
-  
+
   stats_files++;
-  
+
   handle = pcap_open_offline(file, errbuf);
   if (! handle) {
     stats_noncaps++;
     return;
   }
-  
+
   stats_caps++;
-  
+
   if ((pcap_datalink(handle) != DLT_IEEE802_11) && (pcap_datalink(handle) != DLT_PRISM_HEADER)){
     //TODO: Add support for RADIOTAP!!!!
     printf("Dumpfile %s is not an IEEE 802.11 capture: %s\n", file, pcap_datalink_val_to_name(pcap_datalink(handle)));
     pcap_close(handle);
     return;
   }
-  
+
   printf("Scanning dumpfile %s\n", file);
   eapol_networks = get_eapol_bssids(handle);
-  
+
   pcap_close(handle);
   if (! eapol_networks) return; //No WPA networks found, skipping to next file
-  
+
   handle = pcap_open_offline(file, errbuf);
-  
+
   process_eapol_networks(handle, eapol_networks);
   pcap_close(handle);
-  
+
   free_bsslist(eapol_networks);
 }
 
 
-void process_directory(const char *dir, time_t begin) {
+static void process_directory(const char *dir, time_t begin) {
   DIR *curdir;
   struct dirent *curent;
   struct stat curstat;
   char *fullname;
-  
+
   stats_dirs++;
-  
+
   curdir = opendir(dir);
-  
+
   if (! curdir) {
     perror("Opening directory failed");
     return;
   }
-  
+
   errno = 0;
   curent = readdir(curdir);
-  
+
   while(curent) {
     if ((! strcmp("..", curent->d_name)) || (! strcmp(".", curent->d_name))) {
       curent = readdir(curdir);
       continue;
     }
-    
+
     fullname = malloc(strlen(dir) + strlen(curent->d_name) + 2);
     memcpy(fullname, dir, strlen(dir) + 1);
     strcat(fullname, "/"); strcat(fullname, curent->d_name);
-    
+
     if (stat(fullname, &curstat)) {
       printf("Statting %s ", fullname); perror("failed");
     } else {
@@ -306,13 +306,13 @@ void process_directory(const char *dir, time_t begin) {
 	printf("%s is a neither a directory nor a regular file\n", fullname);
       }
     }
-    
+
     free(fullname);
     curent = readdir(curdir);
   }
-  
+
   if (errno) perror("Reading directory failed");
-  
+
   closedir(curdir);
   return;
 }
@@ -320,7 +320,7 @@ void process_directory(const char *dir, time_t begin) {
 
 int main(int argc, char *argv[]) {
   time_t begin = time(NULL);	//Every file newer than when crawler started is skipped (it may be the file the crawler created!)
-  
+
   if (argc != 3) {
     printf("Use: %s <SearchDir> <CapFileOut>\n", argv[0]);
     printf("What does it do?\n\nIt recurses the SearchDir directory\n");
@@ -330,15 +330,15 @@ int main(int argc, char *argv[]) {
     printf("This tool is supposed to crawl capfiles for upload to sorbo's WPA statistic server!\n");
     exit(0);
   }
-  
+
   dumphandle = pcap_open_dead(DLT_IEEE802_11, BUFSIZ);
   dumper = pcap_dump_open(dumphandle, argv[2]);
-  
+
   process_directory(argv[1], begin);
-  
+
   pcap_dump_close(dumper);
   pcap_close(dumphandle);
-  
+
   printf("DONE. Statistics:\n");
   printf("Files scanned:      %12d\n", stats_files);
   printf("Directories scanned:%12d\n", stats_dirs);
@@ -347,6 +347,6 @@ int main(int argc, char *argv[]) {
   printf("Packets processed:  %12d\n", stats_packets);
   printf("EAPOL packets:      %12d\n", stats_eapols);
   printf("WPA Network count:  %12d\n", stats_networks);
-  
+
   return 0;
 }

--- a/src/common.c
+++ b/src/common.c
@@ -53,6 +53,8 @@
 #define isHex(c) (hexToInt(c) != -1)
 #define HEX_BASE 16
 
+#include "common.h"
+
 /*
  * The following function comes from jumbo.c from JTR.
  * It has the following license:
@@ -232,7 +234,7 @@ char * getVersion(char * progname, int maj, int min, int submin, int svnrev, int
 }
 
 // Return the number of cpu. If detection fails, it will return -1;
-int get_nb_cpus()
+int get_nb_cpus(void)
 {
         int number = -1;
 

--- a/src/common.h
+++ b/src/common.h
@@ -84,5 +84,16 @@ int64_t ftello64(FILE * fp);
 #endif
 
 void calctime(time_t t, float calc);
+int is_string_number(const char * str);
+int get_ram_size(void);
+char *getVersion(char * progname, int maj, int min, int submin, int svnrev, int beta, int rc);
+int get_nb_cpus(void);
+int maccmp(unsigned char *mac1, unsigned char *mac2);
+char *mac2string(unsigned char *mac_address);
+int hexCharToInt(unsigned char c);
+int hexStringToArray(char* in, int in_length, unsigned char* out, int out_length);
+//int getmac(char * macAddress, int strict, unsigned char * mac);
+int readLine(char line[], int maxlength);
+int hexToInt(char s[], int len);
 
 #endif

--- a/src/cpuid.c
+++ b/src/cpuid.c
@@ -58,7 +58,7 @@ struct _cpuinfo cpuinfo = { 0, NULL, NULL, 0, 0, 0, 0, 0, 0, 0, 0.0, NULL };
 //
 // Until better support for other arch's is added an ifdef is needed
 //
-unsigned long getRegister(const unsigned int val, const char from, const char to) {
+static unsigned long getRegister(const unsigned int val, const char from, const char to) {
 	unsigned long mask = (1<<(to+1)) - 1;
 
 	if (to == 31)
@@ -67,14 +67,14 @@ unsigned long getRegister(const unsigned int val, const char from, const char to
 	return (val & mask) >> from;
 }
 
-void sprintcat(char *dest, const char *src, size_t len) {
+static void sprintcat(char *dest, const char *src, size_t len) {
 	if (strlen(dest))
 		(void)strncat(dest, ",", len);
 
 	(void)strncat(dest, src, len);
 }
 
-int is_dir(const char *dir) {
+static int is_dir(const char *dir) {
 	struct stat sb;
 
 	if (!stat(dir, &sb))
@@ -83,7 +83,7 @@ int is_dir(const char *dir) {
 	return 0;
 }
 
-unsigned long GetCacheTotalLize(unsigned ebx, unsigned ecx) {
+static unsigned long GetCacheTotalLize(unsigned ebx, unsigned ecx) {
 	unsigned long  LnSz, SectorSz, WaySz, SetSz;
         LnSz = getRegister(ebx, 0, 11 ) + 1;
         SectorSz = getRegister(ebx, 12, 21 ) + 1;
@@ -135,7 +135,7 @@ int cpuid_simdsize(int viewmax) {
 }
 
 #ifdef _X86
-char* cpuid_vendor() {
+static char* cpuid_vendor(void) {
 	unsigned eax = 0, ebx = 0, ecx = 0, edx = 0;
 
 	__cpuid(0, eax, ebx, ecx, edx);
@@ -179,7 +179,7 @@ char* cpuid_vendor() {
 }
 #endif
 
-char* cpuid_featureflags() {
+static char* cpuid_featureflags(void) {
 	char flags[64] = {0};
 #ifdef _X86
 	unsigned eax = 0, ebx = 0, ecx = 0, edx = 0;
@@ -269,7 +269,7 @@ char* cpuid_featureflags() {
 	return strdup(flags);
 }
 
-float cpuid_getcoretemp() {
+static float cpuid_getcoretemp(void) {
 #ifdef __FreeBSD__
 	int tempval = 0;
 	size_t len = sizeof(tempval);
@@ -361,7 +361,7 @@ int cpuid_readsysfs(const char *file) {
 //
 // Return CPU frequency from scaling governor when supported
 //
-int cpuid_getfreq(int type) {
+static int cpuid_getfreq(int type) {
 	int fd, ifreq = 0;
 	struct stat sf;
 	char freq[16] = {0}, *fptr;
@@ -385,7 +385,7 @@ int cpuid_getfreq(int type) {
 }
 #endif
 
-char* cpuid_modelinfo() {
+static char* cpuid_modelinfo(void) {
 #ifdef _X86
 	unsigned eax = 0, ebx = 0, ecx = 0, edx = 0;
 	int bi = 2, broff = 0;
@@ -471,7 +471,7 @@ char* cpuid_modelinfo() {
 	return model;
 }
 
-int cpuid_getinfo() {
+int cpuid_getinfo(void) {
 	int cpu_count = get_nb_cpus();
 	float cpu_temp;
 #ifdef _X86

--- a/src/crypto.c
+++ b/src/crypto.c
@@ -104,7 +104,7 @@ int decrypt_wep( unsigned char *data, int len, unsigned char *key, int keylen )
 
 /* An implementation of the ARC4 algorithm */
 
-void rc4_setup( struct rc4_state *s, unsigned char *key,  int length )
+static void rc4_setup( struct rc4_state *s, unsigned char *key,  int length )
 {
     int i, j, k, *m, a;
 
@@ -128,7 +128,7 @@ void rc4_setup( struct rc4_state *s, unsigned char *key,  int length )
     }
 }
 
-void rc4_crypt( struct rc4_state *s, unsigned char *data, int length )
+static void rc4_crypt( struct rc4_state *s, unsigned char *data, int length )
 {
     int i, x, y, *m, a, b;
 
@@ -360,7 +360,7 @@ void calc_mic (struct AP_info *ap, unsigned char pmk[32], unsigned char ptk[80],
 
 }
 
-unsigned long calc_crc( unsigned char * buf, int len)
+static unsigned long calc_crc( unsigned char * buf, int len)
 {
     unsigned long crc = 0xFFFFFFFF;
 
@@ -371,7 +371,7 @@ unsigned long calc_crc( unsigned char * buf, int len)
 }
 
 //without inversion, must be used for bit flipping attacks
-unsigned long calc_crc_plain( unsigned char * buf, int len)
+static unsigned long calc_crc_plain( unsigned char * buf, int len)
 {
     unsigned long crc = 0x00000000;
 
@@ -430,7 +430,7 @@ int calc_crc_buf( unsigned char *buf, int len )
     return (calc_crc(buf, len));
 }
 
-void *get_da(unsigned char *wh)
+static void *get_da(unsigned char *wh)
 {
         if (wh[1] & IEEE80211_FC1_DIR_FROMDS)
                 return wh + 4;
@@ -438,7 +438,7 @@ void *get_da(unsigned char *wh)
                 return wh + 4 + 6*2;
 }
 
-void *get_sa(unsigned char *wh)
+static void *get_sa(unsigned char *wh)
 {
         if (wh[1] & IEEE80211_FC1_DIR_FROMDS)
                 return wh + 4 + 6*2;
@@ -462,7 +462,7 @@ int is_dhcp_discover(void *wh, int len)
     return 0;
 }
 
-int is_arp(void *wh, int len)
+static int is_arp(void *wh, int len)
 {
         int arpsize = 8 + 8 + 10*2;
 
@@ -476,7 +476,7 @@ int is_arp(void *wh, int len)
         return 0;
 }
 
-int is_wlccp(void *wh, int len)
+static int is_wlccp(void *wh, int len)
 {
 	int wlccpsize = 58;
 
@@ -508,7 +508,7 @@ int is_qos_arp_tkip(void *wh, int len)
         return 0;
 }
 
-int is_spantree(void *wh)
+static int is_spantree(void *wh)
 {
         if ( wh != NULL &&
 	     (memcmp( wh +  4, SPANTREE, 6 ) == 0 ||
@@ -518,7 +518,7 @@ int is_spantree(void *wh)
         return 0;
 }
 
-int is_cdp_vtp(void *wh)
+static int is_cdp_vtp(void *wh)
 {
         if ( memcmp( wh +  4, CDP_VTP, 6 ) == 0 ||
              memcmp( wh + 16, CDP_VTP, 6 ) == 0 )
@@ -715,7 +715,7 @@ int calc_ptk( struct WPA_ST_info *wpa, unsigned char pmk[32] )
     return( memcmp( mic, wpa->keymic, 16 ) == 0 );
 }
 
-int init_michael(struct Michael *mic, unsigned char key[8])
+static int init_michael(struct Michael *mic, unsigned char key[8])
 {
     mic->key0 = key[0]<<0 | key[1]<<8 | key[2]<<16 | key[3]<<24;
     mic->key1 = key[4]<<0 | key[5]<<8 | key[6]<<16 | key[7]<<24;
@@ -727,7 +727,7 @@ int init_michael(struct Michael *mic, unsigned char key[8])
     return 0;
 }
 
-int michael_append_byte(struct Michael *mic, unsigned char byte)
+static int michael_append_byte(struct Michael *mic, unsigned char byte)
 {
     mic->message |= (byte << (8*mic->nBytesInM));
     mic->nBytesInM++;
@@ -750,7 +750,7 @@ int michael_append_byte(struct Michael *mic, unsigned char byte)
     return 0;
 }
 
-int michael_remove_byte(struct Michael *mic, unsigned char bytes[4])
+static int michael_remove_byte(struct Michael *mic, unsigned char bytes[4])
 {
     if( mic->nBytesInM == 0 )
     {
@@ -773,7 +773,7 @@ int michael_remove_byte(struct Michael *mic, unsigned char bytes[4])
     return 0;
 }
 
-int michael_append(struct Michael *mic, unsigned char *bytes, int length)
+static int michael_append(struct Michael *mic, unsigned char *bytes, int length)
 {
     while(length > 0)
     {
@@ -783,7 +783,7 @@ int michael_append(struct Michael *mic, unsigned char *bytes, int length)
     return 0;
 }
 
-int michael_remove(struct Michael *mic, unsigned char *bytes, int length)
+static int michael_remove(struct Michael *mic, unsigned char *bytes, int length)
 {
     while(length >= 4)
     {
@@ -793,7 +793,7 @@ int michael_remove(struct Michael *mic, unsigned char *bytes, int length)
     return 0;
 }
 
-int michael_finalize(struct Michael *mic)
+static int michael_finalize(struct Michael *mic)
 {
     // Append the minimum padding
     michael_append_byte(mic, 0x5a );
@@ -819,7 +819,7 @@ int michael_finalize(struct Michael *mic)
     return 0;
 }
 
-int michael_finalize_zero(struct Michael *mic)
+static int michael_finalize_zero(struct Michael *mic)
 {
     // Append the minimum padding
     michael_append_byte(mic, 0 );
@@ -1186,7 +1186,7 @@ int calc_tkip_ppk( unsigned char *h80211, int caplen, unsigned char TK1[16], uns
     return 0;
 }
 
-int calc_tkip_mic_skip_eiv(unsigned char* packet, int length, unsigned char ptk[80], unsigned char value[8])
+static int calc_tkip_mic_skip_eiv(unsigned char* packet, int length, unsigned char ptk[80], unsigned char value[8])
 {
     int z, koffset=0, is_qos=0;
     unsigned char smac[6], dmac[6], bssid[6];

--- a/src/ivstools.c
+++ b/src/ivstools.c
@@ -100,7 +100,7 @@ static unsigned char ZERO[32] =
 
 extern char * getVersion(char * progname, int maj, int min, int submin, int svnrev, int beta, int rc);
 
-void usage(int what)
+static void usage(int what)
 {
     char *version_info = getVersion("ivsTools", _MAJ, _MIN, _SUB_MIN, _REVISION, _BETA, _RC);
     printf("\n  %s - (C) 2006-2015 Thomas d\'Otreppe\n"
@@ -117,7 +117,7 @@ void usage(int what)
                 "        Merge ivs files\n");
 }
 
-int merge( int argc, char *argv[] )
+static int merge( int argc, char *argv[] )
 {
     int i, n, unused;
     unsigned long nbw;
@@ -216,7 +216,7 @@ int merge( int argc, char *argv[] )
     return( 0 );
 }
 
-int dump_add_packet( unsigned char *h80211, unsigned caplen)
+static int dump_add_packet( unsigned char *h80211, unsigned caplen)
 {
     int i, n, seq, dlen, clen;
     unsigned z;

--- a/src/kstats.c
+++ b/src/kstats.c
@@ -53,7 +53,7 @@ int K_COEFF[N_ATTACKS] =
         15, 13, 12, 12, 12, 5, 5, 5, 3, 4, 3, 4, 3, 13, 4, 4, -20
 };
 
-void calc_votes( unsigned char *ivbuf, long nb_ivs,
+static void calc_votes( unsigned char *ivbuf, long nb_ivs,
                  unsigned char *key, int B,
                  int votes[N_ATTACKS][256] )
 {
@@ -243,7 +243,7 @@ void calc_votes( unsigned char *ivbuf, long nb_ivs,
 
 typedef struct { int idx, val; } vote;
 
-int cmp_votes( const void *bs1, const void *bs2 )
+static int cmp_votes( const void *bs1, const void *bs2 )
 {
     if( ((vote *) bs1)->val < ((vote *) bs2)->val )
         return(  1 );

--- a/src/linecount.cpp
+++ b/src/linecount.cpp
@@ -64,12 +64,12 @@
 
 using namespace std;
 
-unsigned int FileRead(istream &is, vector <char> &buff) {
+static unsigned int FileRead(istream &is, vector <char> &buff) {
 	is.read(&buff[0], buff.size());
 	return is.gcount();
 }
 
-unsigned int countBuffer(const vector <char> &buff, int bufsize) {
+static unsigned int countBuffer(const vector <char> &buff, int bufsize) {
 	int lines = 0, i = 4;
 	const char * p = &buff[0];
 	unsigned short charct = 0;

--- a/src/memory.c
+++ b/src/memory.c
@@ -102,7 +102,7 @@ static void add_memory_link(void *v) {
 	MEMDBG_tag_mem_from_alloc_tiny((void*)p);
 }
 // call at program exit.
-void cleanup_tiny_memory()
+void cleanup_tiny_memory(void)
 {
 	struct rm_list *p = mem_alloc_tiny_memory, *p2;
 	for (;;) {

--- a/src/memory.h
+++ b/src/memory.h
@@ -257,7 +257,7 @@ extern char *str_alloc_copy_func(char *src
  * of that memory was 'blindly' allocated, and not freed up during
  * the run of john.  Now, it is 'cleaned' up.
  */
-extern void cleanup_tiny_memory();
+extern void cleanup_tiny_memory(void);
 
 
 void dump_text(void *in, int len);

--- a/src/osdep/linux.c
+++ b/src/osdep/linux.c
@@ -150,7 +150,7 @@ struct priv_linux {
 #define NULL_MAC        "\x00\x00\x00\x00\x00\x00"
 #endif
 
-unsigned long calc_crc_osdep( unsigned char * buf, int len)
+static unsigned long calc_crc_osdep( unsigned char * buf, int len)
 {
     unsigned long crc = 0xFFFFFFFF;
 
@@ -162,7 +162,7 @@ unsigned long calc_crc_osdep( unsigned char * buf, int len)
 
 /* CRC checksum verification routine */
 
-int check_crc_buf_osdep( unsigned char *buf, int len )
+static int check_crc_buf_osdep( unsigned char *buf, int len )
 {
     unsigned long crc;
 
@@ -1216,7 +1216,7 @@ static int opensysfs(struct priv_linux *dev, char *iface, int fd) {
     return 0;
 }
 
-int linux_get_monitor(struct wif *wi)
+static int linux_get_monitor(struct wif *wi)
 {
     struct priv_linux *dev = wi_priv(wi);
     struct ifreq ifr;
@@ -1269,7 +1269,7 @@ int linux_get_monitor(struct wif *wi)
     return( 0 );
 }
 
-int set_monitor( struct priv_linux *dev, char *iface, int fd )
+static int set_monitor( struct priv_linux *dev, char *iface, int fd )
 {
     int pid, status, unused;
     struct iwreq wrq;

--- a/src/packetforge-ng.c
+++ b/src/packetforge-ng.c
@@ -162,7 +162,7 @@ dev;
 unsigned char h80211[2048];
 unsigned char tmpbuf[2048];
 
-int capture_ask_packet( int *caplen )
+static int capture_ask_packet( int *caplen )
 {
     time_t tr;
     struct timeval tv;
@@ -373,7 +373,7 @@ int capture_ask_packet( int *caplen )
     return( 0 );
 }
 
-int packet_dump(unsigned char* packet, int length)
+static int packet_dump(unsigned char* packet, int length)
 {
     int i;
 
@@ -391,7 +391,7 @@ int packet_dump(unsigned char* packet, int length)
 }
 
 /* IP address parsing routine */
-int getip( char *s, unsigned char *ip , unsigned short *port)
+static int getip( char *s, unsigned char *ip , unsigned short *port)
 {
     int i = 0, n;
 
@@ -425,7 +425,7 @@ int getip( char *s, unsigned char *ip , unsigned short *port)
     return( i != 4 );
 }
 
-unsigned short ip_chksum(unsigned short* addr, int count)
+static unsigned short ip_chksum(unsigned short* addr, int count)
 {
 	unsigned short checksum;
 	   /* Compute Internet Checksum for "count" bytes
@@ -454,7 +454,7 @@ unsigned short ip_chksum(unsigned short* addr, int count)
     return checksum;
 }
 
-int set_tofromds(unsigned char* packet)
+static int set_tofromds(unsigned char* packet)
 {
     if(packet == NULL) return 1;
 
@@ -482,7 +482,7 @@ int set_tofromds(unsigned char* packet)
     return 0;
 }
 
-int set_bssid(unsigned char* packet)
+static int set_bssid(unsigned char* packet)
 {
     int mi_b;
 
@@ -508,7 +508,7 @@ int set_bssid(unsigned char* packet)
     return 0;
 }
 
-int set_dmac(unsigned char* packet)
+static int set_dmac(unsigned char* packet)
 {
     int mi_d;
 
@@ -534,7 +534,7 @@ int set_dmac(unsigned char* packet)
     return 0;
 }
 
-int set_smac(unsigned char* packet)
+static int set_smac(unsigned char* packet)
 {
     int mi_s;
 
@@ -561,7 +561,7 @@ int set_smac(unsigned char* packet)
 }
 
 /* offset for ip&&udp = 48, for arp = 56 */
-int set_dip(unsigned char* packet, int offset)
+static int set_dip(unsigned char* packet, int offset)
 {
     if(packet == NULL) return 1;
     if(offset < 0 || offset > 2046) return 1;
@@ -579,7 +579,7 @@ int set_dip(unsigned char* packet, int offset)
 }
 
 /* offset for ip&&udp = 44, for arp = 46 */
-int set_sip(unsigned char* packet, int offset)
+static int set_sip(unsigned char* packet, int offset)
 {
     if(packet == NULL) return 1;
     if(offset < 0 || offset > 2046) return 1;
@@ -596,7 +596,7 @@ int set_sip(unsigned char* packet, int offset)
     return 0;
 }
 
-int set_ipid(unsigned char* packet, int offset)
+static int set_ipid(unsigned char* packet, int offset)
 {
     unsigned short id;
 
@@ -610,7 +610,7 @@ int set_ipid(unsigned char* packet, int offset)
     return 0;
 }
 
-int set_dport(unsigned char* packet)
+static int set_dport(unsigned char* packet)
 {
     unsigned short port;
 
@@ -622,7 +622,7 @@ int set_dport(unsigned char* packet)
     return 0;
 }
 
-int set_sport(unsigned char* packet)
+static int set_sport(unsigned char* packet)
 {
     unsigned short port;
 
@@ -634,7 +634,7 @@ int set_sport(unsigned char* packet)
     return 0;
 }
 
-int set_ip_ttl(unsigned char* packet)
+static int set_ip_ttl(unsigned char* packet)
 {
     unsigned char ttl;
 
@@ -646,7 +646,7 @@ int set_ip_ttl(unsigned char* packet)
     return 0;
 }
 
-int set_IVidx(unsigned char* packet)
+static int set_IVidx(unsigned char* packet)
 {
     if(packet == NULL) return 1;
 
@@ -662,7 +662,7 @@ int set_IVidx(unsigned char* packet)
     return 0;
 }
 
-int next_keystream(unsigned char *dest, int size, unsigned char *bssid, int minlen)
+static int next_keystream(unsigned char *dest, int size, unsigned char *bssid, int minlen)
 {
     struct ivs2_pkthdr ivs2;
     char *buffer;
@@ -726,7 +726,7 @@ int next_keystream(unsigned char *dest, int size, unsigned char *bssid, int minl
     return -1;
 }
 
-int encrypt_data(unsigned char *dest, unsigned char* data, int length)
+static int encrypt_data(unsigned char *dest, unsigned char* data, int length)
 {
     unsigned char cipher[2048];
     int n;
@@ -778,7 +778,7 @@ int encrypt_data(unsigned char *dest, unsigned char* data, int length)
     return 0;
 }
 
-int create_wep_packet(unsigned char* packet, int *length)
+static int create_wep_packet(unsigned char* packet, int *length)
 {
     if(packet == NULL) return 1;
 
@@ -800,7 +800,7 @@ int create_wep_packet(unsigned char* packet, int *length)
     return 0;
 }
 
-int read_raw_packet(unsigned char* dest, char* srcfile, int length)
+static int read_raw_packet(unsigned char* dest, char* srcfile, int length)
 {
     size_t readblock;
     FILE *f;
@@ -829,7 +829,7 @@ int read_raw_packet(unsigned char* dest, char* srcfile, int length)
     return 0;
 }
 
-int write_cap_packet(unsigned char* packet, int length)
+static int write_cap_packet(unsigned char* packet, int length)
 {
     FILE *f;
     struct pcap_file_header pfh;
@@ -910,7 +910,7 @@ int write_cap_packet(unsigned char* packet, int length)
     return 0;
 }
 
-int read_prga(unsigned char **dest, char *file)
+static int read_prga(unsigned char **dest, char *file)
 {
     FILE *f;
     int size;
@@ -976,7 +976,7 @@ int read_prga(unsigned char **dest, char *file)
     return( 0 );
 }
 
-int forge_arp()
+static int forge_arp(void)
 {
 
     /* use arp request */
@@ -998,7 +998,7 @@ int forge_arp()
     return 0;
 }
 
-int forge_udp()
+static int forge_udp(void)
 {
     unsigned short chksum;
 
@@ -1027,7 +1027,7 @@ int forge_udp()
     return 0;
 }
 
-int forge_icmp()
+static int forge_icmp(void)
 {
     unsigned short chksum;
 
@@ -1058,7 +1058,7 @@ int forge_icmp()
     return 0;
 }
 
-int forge_null()
+static int forge_null(void)
 {
     opt.pktlen = opt.size;
     memcpy(h80211, NULL_PACKET, 24);
@@ -1080,7 +1080,7 @@ int forge_null()
     return 0;
 }
 
-int forge_custom()
+static int forge_custom(void)
 {
     if(capture_ask_packet( &opt.pktlen ) != 0) return 1;
 //    if(read_raw_packet(h80211, opt.raw_file, opt.pktlen) != 0) return 1;
@@ -1103,7 +1103,7 @@ int forge_custom()
     return 0;
 }
 
-void print_usage(void)
+static void print_usage(void)
 {
     char *version_info = getVersion("Packetforge-ng", _MAJ, _MIN, _SUB_MIN, _REVISION, _BETA, _RC);
     printf(usage, version_info);

--- a/src/simd-intrinsics.c
+++ b/src/simd-intrinsics.c
@@ -1741,7 +1741,7 @@ void sha256_reverse(uint32_t *hash)
 	hash[0] = e - (a - (s0 + maj));
 }
 
-void sha256_unreverse()
+void sha256_unreverse(void)
 {
 	fprintf(stderr, "sha256_unreverse() not implemented\n");
 	perror("sha256_unreverse");
@@ -2322,7 +2322,7 @@ void sha512_reverse(uint64_t *hash)
 	hash[0] = e - (a - (s0 + maj));
 }
 
-void sha512_unreverse()
+void sha512_unreverse(void)
 {
 	fprintf(stderr, "sha512_unreverse() not implemented\n");
 	perror("sha512");

--- a/src/simd-intrinsics.h
+++ b/src/simd-intrinsics.h
@@ -150,7 +150,7 @@ void SIMDSHA256body(vtype* data, ARCH_WORD_32 *out, ARCH_WORD_32 *reload_state, 
 void sha224_reverse(uint32_t *hash);
 void sha224_unreverse(uint32_t *hash);
 void sha256_reverse(uint32_t *hash);
-void sha256_unreverse();
+void sha256_unreverse(void);
 #endif
 
 #ifdef SIMD_COEF_64
@@ -159,7 +159,7 @@ void SIMDSHA512body(vtype* data, ARCH_WORD_64 *out, ARCH_WORD_64 *reload_state, 
 void sha384_reverse(ARCH_WORD_64 *hash);
 void sha384_unreverse(ARCH_WORD_64 *hash);
 void sha512_reverse(ARCH_WORD_64 *hash);
-void sha512_unreverse();
+void sha512_unreverse(void);
 #endif
 
 #else

--- a/src/wpapsk.h
+++ b/src/wpapsk.h
@@ -77,7 +77,7 @@ extern unsigned char *xsse_crypt2[128];
 #define PLAINTEXT_LENGTH	63 /* We can do 64 but spec. says 63 */
 
 int threadxnt;
-void init_atoi();
+void init_atoi(void);
 void init_ssecore(int);
 void free_ssecore(int);
 int init_wpapsk(char (*key)[128], char *essid, int threadid);


### PR DESCRIPTION
Found using -Wmissing-prototypes, -Wstrict-prototypes, and -Wmissing-declarations.

Compile tested but not runtime tested.