### PR TITLE
Fix creation of .xor files

### DIFF
--- a/src/airodump-ng.c
+++ b/src/airodump-ng.c
@@ -500,7 +500,7 @@ int check_shared_key(unsigned char *h80211, int caplen)
     if( time(NULL) - G.sk_start > 5)
     {
         /* timeout(5sec) - remove all packets, restart timer */
-        memset(G.sharedkey, '\x00', 4096*3);
+        memset(G.sharedkey, '\x00', sizeof(G.sharedkey));
         G.sk_start = time(NULL);
     }
 
@@ -647,7 +647,7 @@ int check_shared_key(unsigned char *h80211, int caplen)
                 textlen+4, *(G.sharedkey[0]+m_bmac), *(G.sharedkey[0]+m_bmac+1), *(G.sharedkey[0]+m_bmac+2),
               *(G.sharedkey[0]+m_bmac+3), *(G.sharedkey[0]+m_bmac+4), *(G.sharedkey[0]+m_bmac+5));
 
-    memset(G.sharedkey, '\x00', 512*3);
+    memset(G.sharedkey, '\x00', sizeof(G.sharedkey));
     /* ok, keystream saved */
     return 0;
 }
@@ -6300,7 +6300,7 @@ int main( int argc, char *argv[] )
 	// Default selection.
     resetSelection();
 
-    memset(G.sharedkey, '\x00', 512*3);
+    memset(G.sharedkey, '\x00', sizeof(G.sharedkey));
     memset(G.message, '\x00', sizeof(G.message));
     memset(&G.pfh_in, '\x00', sizeof(struct pcap_file_header));
 


### PR DESCRIPTION
<strike>first 2 commits are necessary to fix build on my host system (sabotage linux, using libressl and musl libc).</strike> then there are 2 commits that fix 2 issues both introduced in commit d12d0803e625e6c0d5cef2be8b91009e8041eaee .

the first issue was that even with several dozens complete SKA handshakes, i always got "Broken SKA" message. When googling for that message, i found dozens of forum posts from users complaining about this message, most often answered with "probably a bug in aircrack".

after i patched the broken check out, i was able to get .xor files, however they did not work.
i then tried with version 1.0-beta2 which was before the bad commit, and with the .xor file created by it, i was able to auth.

i then git bisected between master and the known good commit and compared md5 sum of the generated .xor file when running my .pcap file through it. to my surprise, the culprit was the same commit that introduced the "Broken SKA" check!

more info in #125

update: per request moved libressl and sys_queue fix into separate PRs, #127 and #128