### PR TITLE
airventriloquist-ng: remove gratuitous inclusion of sys/queue.h

### DIFF
--- a/src/airventriloquist-ng.c
+++ b/src/airventriloquist-ng.c
@@ -62,7 +62,6 @@
 #include <netinet/in_systm.h>
 #include <netinet/ip.h>
 #include <netinet/tcp.h>
-#include <sys/queue.h>
 #include <arpa/inet.h>
 
 #include <fnmatch.h>


### PR DESCRIPTION
this header is non-standard and caused compilation error with musl libc.
since it was not even used, it's safe to remove it.