### PR TITLE
Fix nexmon disable monitor mode message

### DIFF
--- a/scripts/airmon-ng
+++ b/scripts/airmon-ng
@@ -663,7 +663,7 @@ stopNexmonIface() {
 	ifconfig $1 down
 	nexutil -m0
 	ifconfig $1 up 2> /dev/null
-	printf "\n\t\t(monitor mode enabled for [${PHYDEV}]${1})\n"
+	printf "\n\t\t(monitor mode disabled for [${PHYDEV}]${1})\n"
 }
 
 stopwlIface() {


### PR DESCRIPTION
When disabling the interface when using nexmon firmware on the rpi3, it
was stating that monitor mode is enabled.  Fix the typo so that it shows
as disabled.